### PR TITLE
(helm) Added helm_release rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,42 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | repository_url | true | - | The url of the the chart museum repository. **IMPORTANT: The url must end with slash /**  |
 | repository_username | true | - | The username to login in to the chart museum registry using basic auth. It supports the use of `make_variables` |
 | repository_password | true | - | The password to login in to the chart museum registry using basic auth. It supports the use of `make_variables` |
+
+
+### helm_release
+
+`helm_release` is used to create and deploy a new release in a Kubernetes Cluster.
+
+Only `Helm 2` is supported for the moment.
+
+It has support for secrets via helm secrets (sops), which allows to have encrypted values files in the Git repository.
+
+This rule is an executable. It needs `run` instead of `build` to be invoked.
+
+It relies in existing local kubernetes config (`~/.kube/config`).
+
+Example of use:
+```
+helm_release(
+    name = "chart_install",
+    chart = ":chart",
+    namespace = "myapp",
+    tiller_namespace = "tiller-system",
+    release_name = "release-name",
+    values_yaml = glob(["charts/myapp/values.yaml"]),
+    secrets_yaml = glob(["charts/myapp/secrets.*.yaml"]),
+    sops_yaml = ".sops.yaml",
+)
+```
+
+The following attributes are accepted by the rule (some of them are mandatory).
+
+|  Attribute | Mandatory| Default | Notes |
+| ---------- | --- | ------ | -------------- |
+| chart | yes | - | Chart package (targz). Must be a label that specifies where the helm package file (Chart.yaml) is. It accepts the path of the targz file (that bazel will resolve to the file) or the label to a target rule that generates a helm package as output (`helm_chart` rule). |
+| namespace | true | default | Namespace where this release is installed to. It supports the use of `stamp_variables`. |
+| tiller_namespace | true | kube-system | Namespace where Tiller lives in the Kubernetes Cluste. It supports the use of `stamp_variables`.|
+| release_name | true | - | Name of the Helm release. It supports the use of `stamp_variables`|
+| values_yaml | false | - | Several values files can be passed when installing release |
+| secrets_yaml | false | - | Several values files encryopted can be passed when installing release. **IMPORTANT: It requires `helm secrets` plugin to be installed and also define `sops_yaml` for sops configuration**  |
+| sops_yaml | false | - | Provide when using `secrets_yaml`. Check  https://github.com/futuresimple/helm-secrets documentation for further information |

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -1,0 +1,91 @@
+# Load docker image providers
+load(
+    "@io_bazel_rules_docker//container:providers.bzl",
+    "ImageInfo",
+    "LayerInfo",
+)
+
+load("//helpers:helpers.bzl", "write_sh", "get_make_value_or_default")
+
+def runfile(ctx, f):
+  """Return the runfiles relative path of f."""
+  if ctx.workspace_name:
+    return ctx.workspace_name + "/" + f.short_path
+  else:
+    return f.short_path
+
+def _helm_release_impl(ctx):
+    """Installs or upgrades a helm release.
+    Args:
+        name: A unique name for this rule.
+        chart: Chart to install
+        namespace: Namespace where release is installed to
+        release_name: Name of the helm release
+        values_yaml: Specify values yaml to override default
+        secrets_yaml: Specify sops encrypted values to override defaulrt values (need to define sops_value as well)
+        sops_yaml = Sops file if secrets_yaml is provided
+    """
+    
+    chart = ctx.file.chart
+    namespace = ctx.attr.namespace
+    tiller_namespace = ctx.attr.tiller_namespace
+    release_name = ctx.attr.release_name
+
+    stamp_files = [ctx.info_file, ctx.version_file]
+    
+    values_yaml = ""
+    for i, values_yaml_file in enumerate(ctx.files.values_yaml):
+        values_yaml = values_yaml + " -f " + values_yaml_file.path
+    
+    secrets_yaml = ""
+    for i, secrets_yaml_file in enumerate(ctx.files.secrets_yaml):
+        secrets_yaml = secrets_yaml + " -f " + secrets_yaml_file.path
+
+    if secrets_yaml != "" and not ctx.file.sops_yaml:
+        fail(msg='sops_yaml must be provided if secrets_yaml is set')
+
+    exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")
+
+    # Generates the exec bash file with the provided substitutions
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = exec_file,
+        is_executable = True,
+        substitutions = {
+            "{CHART_PATH}": chart.short_path,
+            "{NAMESPACE}": namespace,
+            "{TILLER_NAMESPACE}": tiller_namespace,
+            "{RELEASE_NAME}": release_name,
+            "{VALUES_YAML}": values_yaml,
+            "{SECRETS_YAML}": secrets_yaml,
+            "%{stamp_statements}": "\n".join([
+              "\tread_variables %s" % runfile(ctx, f)
+              for f in stamp_files]),
+        }
+    )
+
+    runfiles = ctx.runfiles(
+        files = [chart, ctx.info_file, ctx.version_file] + ctx.files.values_yaml + ctx.files.secrets_yaml + ctx.files.sops_yaml
+    )
+
+    return [DefaultInfo(
+      executable = exec_file,
+      runfiles = runfiles,
+    )]
+
+helm_release = rule(
+    implementation = _helm_release_impl,
+    attrs = {
+      "chart": attr.label(allow_single_file = True, mandatory = True),
+      "namespace": attr.string(mandatory = True, default = "default"),
+      "tiller_namespace": attr.string(mandatory = True, default = "tiller-system"),
+      "release_name": attr.string(mandatory = True),
+      "values_yaml": attr.label_list(allow_files = True, mandatory = False),
+      "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
+      "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
+      "_script_template": attr.label(allow_single_file = True, default = ":helm-release.sh.tpl"),
+    },
+    doc = "Installs or upgrades a new helm release",
+    toolchains = [],
+    executable = True,
+)

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -1,0 +1,38 @@
+set -e
+set -o pipefail
+
+function guess_runfiles() {
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_files')"
+
+function read_variables() {
+    local file="${RUNFILES}/$1"
+    local new_file="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_new')"
+    echo "${new_file}" >> "${TEMP_FILES}"
+
+    # Rewrite the file from Bazel for the form FOO=...
+    # to a form suitable for sourcing into bash to expose
+    # these variables as substitutions in the tag statements.
+    sed -E "s/^([^ ]+) (.*)\$/export \\1='\\2'/g" < ${file} > ${new_file}
+    source ${new_file}
+}
+
+%{stamp_statements}
+
+
+helm init -c
+if [ "{SECRETS_YAML}" != "" ]; then
+    helm secrets upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {SECRETS_YAML} {RELEASE_NAME} {CHART_PATH}
+else
+    helm upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
+fi

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -2,7 +2,9 @@
 
 load("//helm:helm-chart-package.bzl", _helm_chart = "helm_chart")
 load("//helm:helm-push.bzl", _helm_push = "helm_push")
+load("//helm:helm-release.bzl", _helm_release = "helm_release")
 
 # Explicitly re-export the functions
 helm_chart = _helm_chart
 helm_push = _helm_push
+helm_release = _helm_release


### PR DESCRIPTION
`helm_release` is used to create and deploy a new release in a Kubernetes Cluster.

Only `Helm 2` is supported for the moment.

It has support for secrets via helm secrets (sops), which allows to have encrypted values files in the Git repository.

This rule is an executable. It needs `run` instead of `build` to be invoked.

It relies in existing local kubernetes config (`~/.kube/config`).

Example:

```
helm_release(
    name = "chart_install",
    chart = ":chart",
    namespace = "myapp",
    tiller_namespace = "tiller-system",
    release_name = "release-name",
    values_yaml = glob(["charts/myapp/values.yaml"]),
    secrets_yaml = glob(["charts/myapp/secrets.*.yaml"]),
    sops_yaml = ".sops.yaml",
)
```