### PR TITLE
Remove dependency of image_repository and image_tag

### DIFF
--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -32,9 +32,6 @@ def _helm_chart_impl(ctx):
     # declare rule output
     targz = ctx.actions.declare_file(ctx.attr.package_name + "-" + helm_chart_version + ".tgz")
 
-    if (not ctx.attr.image_tag) and (not ctx.attr.image):
-        fail("Error: 'image' or 'image_tag' arguments must be provided.")
-
     # locate chart root path trying to find Chart.yaml file
     for i, srcfile in enumerate(ctx.files.srcs):
         if srcfile.path.endswith("Chart.yaml"):

--- a/helm/helm-chart-package.sh.tpl
+++ b/helm/helm-chart-package.sh.tpl
@@ -7,29 +7,47 @@ DIGEST_PATH={DIGEST_PATH}
 IMAGE_REPOSITORY={IMAGE_REPOSITORY}
 IMAGE_TAG={IMAGE_TAG}
 
-if [ -z $DIGEST_PATH ] && [ "$IMAGE_TAG" != "" ]; then
-    {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $IMAGE_TAG
-    echo "Packaged image tag: $IMAGE_TAG"
+# Application docker image is not provided by other docker bazel rule
+if  [ -z $DIGEST_PATH ]; then
+
+    # Image repository is provided as a static value
+    if [ "$IMAGE_REPOSITORY" != "" ] && [ -n $IMAGE_REPOSITORY ]; then
+        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH} $IMAGE_REPOSITORY
+        echo "Replaced image repository in chart values.yaml with: $IMAGE_REPOSITORY"
+    fi
+
+    # Image tag is provided as a static value
+    if [ "$IMAGE_TAG" != "" ] && [ -n $IMAGE_TAG ]; then
+        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $IMAGE_TAG
+        echo "Replaced image tag in chart values.yaml with: $IMAGE_TAG"
+    fi
+
 fi
 
+# Application docker image is provided by other docker bazel rule
 if [ -n $DIGEST_PATH ] && [ "$DIGEST_PATH" != "" ]; then
     # extracts the digest sha and removes 'sha256' text from it
     DIGEST=$(cat {DIGEST_PATH})
     IFS=':' read -ra digest_split <<< "$DIGEST"
     DIGEST_SHA=${digest_split[1]}
+
     {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $DIGEST_SHA
-    echo "Packaged image tag: "$DIGEST_SHA
+
+    echo "Replaced image tag in chart values.yaml with: $DIGEST_SHA"
+
     REPO_SUFIX="@sha256"
-    REPO_URL=$({YQ_PATH} r {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH})
-fi
 
-if [ -n $IMAGE_REPOSITORY ] && [ "$IMAGE_REPOSITORY" != "" ]; then
-    REPO_URL="{IMAGE_REPOSITORY}"
-fi
+    if [ -n $IMAGE_REPOSITORY ] && [ "$IMAGE_REPOSITORY" != "" ]; then
+        REPO_URL="{IMAGE_REPOSITORY}"
+    else
+        # if image_repository attr is not provided, extract it from values.yaml
+        REPO_URL=$({YQ_PATH} r {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH})
+    fi
 
-# appends suffix if REPO_URL does not already contains it
-if ([ -n $REPO_URL ] || [ -n $REPO_SUFIX ]) && ([[ $REPO_URL != *"$REPO_SUFIX" ]] || [[ -z "$REPO_SUFIX" ]]); then
-    {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH} ${REPO_URL}${REPO_SUFIX}
+    # appends @sha256 suffix to image repo url value if the repository value does not already contains it
+    if ([ -n $REPO_URL ] || [ -n $REPO_SUFIX ]) && ([[ $REPO_URL != *"$REPO_SUFIX" ]] || [[ -z "$REPO_SUFIX" ]]); then
+        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH} ${REPO_URL}${REPO_SUFIX}
+    fi
 fi
 
 helm init --client-only > /dev/null

--- a/helm/helm-chart-package.sh.tpl
+++ b/helm/helm-chart-package.sh.tpl
@@ -5,21 +5,20 @@ set -o pipefail
 
 DIGEST_PATH={DIGEST_PATH}
 IMAGE_REPOSITORY={IMAGE_REPOSITORY}
+IMAGE_TAG={IMAGE_TAG}
 
-if [ -z $DIGEST_PATH ]; then
-    {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} {IMAGE_TAG}
-    echo "Packaged image tag: {IMAGE_TAG}"
-else
+if [ -z $DIGEST_PATH ] && [ "$IMAGE_TAG" != "" ]; then
+    {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $IMAGE_TAG
+    echo "Packaged image tag: $IMAGE_TAG"
+fi
+
+if [ -n $DIGEST_PATH ] && [ "$DIGEST_PATH" != "" ]; then
     # extracts the digest sha and removes 'sha256' text from it
     DIGEST=$(cat {DIGEST_PATH})
     IFS=':' read -ra digest_split <<< "$DIGEST"
     DIGEST_SHA=${digest_split[1]}
     {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $DIGEST_SHA
     echo "Packaged image tag: "$DIGEST_SHA
-fi
-
-# if the tag is a digest add @sha256 as suffix to the image.repository
-if [ -n $DIGEST_PATH ] && [ "$DIGEST_PATH" != "" ]; then
     REPO_SUFIX="@sha256"
     REPO_URL=$({YQ_PATH} r {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH})
 fi

--- a/tests/charts/nginx-with-deps/BUILD
+++ b/tests/charts/nginx-with-deps/BUILD
@@ -20,6 +20,5 @@ helm_release(
   chart = ":nginx_chart_with_deps",
   namespace = "test-nginx-with-deps",
   release_name = "test-nginx-with-deps",
-  values_yaml = glob(["values.yaml"]),
   tiller_namespace = "tiller-system"
 )

--- a/tests/charts/nginx/BUILD
+++ b/tests/charts/nginx/BUILD
@@ -36,6 +36,13 @@ helm_chart(
   values_repo_yaml_path = "image.repository"
 )
 
+helm_chart(
+  name = "nginx_chart_no_image",
+  srcs = glob(["**"]),
+  helm_chart_version = "1.0.0",
+  package_name = "nginx"
+)
+
 helm_release(
   name = "nginx_helm_release",
   chart = ":nginx_chart",

--- a/tests/rules/package_spec_test.go
+++ b/tests/rules/package_spec_test.go
@@ -116,3 +116,55 @@ func TestChartPackageChartVersionMakeVar(t *testing.T) {
 
 	require.Equal(t, deployment.ObjectMeta.Labels["version"], chartVersion)
 }
+
+func TestChartPackageNoImageNoTag(t *testing.T) {
+	t.Parallel()
+
+	chartVersion := "1.0.0"
+	chartTarPackagePath := "bazel-bin/tests/charts/nginx/nginx-" + chartVersion + ".tgz"
+	chartPackageRootPath := "nginx"
+	relativeChartPackageRootPath := "../../" + chartPackageRootPath
+
+	shell.RunCommand(t, shell.Command{
+		Command:           "bazel",
+		Args:              []string{"build", "//tests/charts/nginx:nginx_chart_no_image"},
+		WorkingDir:        ".",
+		Env:               map[string]string{},
+		OutputMaxLineSize: 1024,
+	})
+
+	shell.RunCommand(t, shell.Command{
+		Command:           "tar",
+		Args:              []string{"-xzf", chartTarPackagePath},
+		WorkingDir:        "../..",
+		Env:               map[string]string{},
+		OutputMaxLineSize: 1024,
+	})
+
+	defer shell.RunCommand(t, shell.Command{
+		Command:           "rm",
+		Args:              []string{"-f", chartTarPackagePath},
+		WorkingDir:        "../..",
+		Env:               map[string]string{},
+		OutputMaxLineSize: 1024,
+	})
+
+	defer shell.RunCommand(t, shell.Command{
+		Command:           "rm",
+		Args:              []string{"-rf", chartPackageRootPath},
+		WorkingDir:        "../..",
+		Env:               map[string]string{},
+		OutputMaxLineSize: 1024,
+	})
+
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{
+			relativeChartPackageRootPath + "/values.yaml",
+		},
+	}, relativeChartPackageRootPath, "nginx", []string{"templates/deployment.yaml"})
+
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Image, "fake-nginx:latest-fake")
+}


### PR DESCRIPTION
Do not fail if no `image`, `image_repository` and `image_tag` are provided to `helm_chart` rule.
Logic refactor of `helm_chart` rule.

