### PR TITLE
Include rules_docker dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,16 +9,10 @@ register_toolchains(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Download the rules_docker repository at release v0.13.0
-http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
-    strip_prefix = "rules_docker-0.13.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
-)
+load("//repositories:repositories.bzl", "repositories")
 
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-container_repositories()
+repositories()
+
+load("//repositories:docker_deps.bzl", "docker_deps")
+
+docker_deps()

--- a/repositories/docker_deps.bzl
+++ b/repositories/docker_deps.bzl
@@ -1,0 +1,8 @@
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+def docker_deps():
+
+  container_repositories()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,5 +1,17 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_archive(
+  name = "io_bazel_rules_docker",
+  sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
+  strip_prefix = "rules_docker-0.13.0",
+  urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
 def repositories():
   native.register_toolchains(
     # Register the default docker toolchain that expects the 'docker'
@@ -7,19 +19,6 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_windows_toolchain",
-  )
-
-
-  http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
-    strip_prefix = "rules_docker-0.13.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
-  )
-
-  load(
-      "@io_bazel_rules_docker//repositories:repositories.bzl",
-      container_repositories = "repositories",
   )
 
   container_repositories()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,16 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-  name = "io_bazel_rules_docker",
-  sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
-  strip_prefix = "rules_docker-0.13.0",
-  urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
-)
-
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
+load(":docker_deps", "docker_deps")
 
 def repositories():
   native.register_toolchains(
@@ -21,4 +10,11 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_windows_toolchain",
   )
 
-  container_repositories()
+  http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
+    strip_prefix = "rules_docker-0.13.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
+  )
+
+  docker_deps()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 def repositories():
   native.register_toolchains(
     # Register the default docker toolchain that expects the 'docker'
@@ -7,7 +9,6 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_windows_toolchain",
   )
 
-  load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
   http_archive(
     name = "io_bazel_rules_docker",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -6,3 +6,19 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_windows_toolchain",
   )
+
+  load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+  http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
+    strip_prefix = "rules_docker-0.13.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
+  )
+
+  load(
+      "@io_bazel_rules_docker//repositories:repositories.bzl",
+      container_repositories = "repositories",
+  )
+
+  container_repositories()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,7 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load(":docker_deps", "docker_deps")
 
 def repositories():
+  """Download dependencies of container rules."""
+  excludes = native.existing_rules().keys()
+
   native.register_toolchains(
     # Register the default docker toolchain that expects the 'docker'
     # executable to be in the PATH
@@ -10,11 +12,10 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/yq:yq_windows_toolchain",
   )
 
-  http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
-    strip_prefix = "rules_docker-0.13.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
-  )
-
-  docker_deps()
+  if "io_bazel_rules_docker" not in excludes:
+    http_archive(
+      name = "io_bazel_rules_docker",
+      sha256 = "df13123c44b4a4ff2c2f337b906763879d94871d16411bf82dcfeba892b58607",
+      strip_prefix = "rules_docker-0.13.0",
+      urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.13.0/rules_docker-v0.13.0.tar.gz"],
+    )

--- a/tests/charts/nginx-with-deps/BUILD
+++ b/tests/charts/nginx-with-deps/BUILD
@@ -20,6 +20,5 @@ helm_release(
   chart = ":nginx_chart_with_deps",
   namespace = "test-nginx-with-deps",
   release_name = "test-nginx-with-deps",
-  values_yaml = glob(["values.yaml"]),
   tiller_namespace = "tiller-system"
 )


### PR DESCRIPTION
Implement a function to automatically load all `rules_docker` dependencies.
This is useful until recursive workspaces get implemented.

This PR has the changes of PR https://github.com/masmovil/bazel-rules/pull/5 .
So https://github.com/masmovil/bazel-rules/pull/5 has to be merged before!