### PR TITLE
Feat/support helm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Helm v3 is now supported.
 
 `helm_release` rule will check if tiller is installed in your cluster to decide which version of helm to use (v2 or v3).
 If the rule can't find any deployed tiller in your cluster, it will use helm v3 by default.
-To find up if you have running tiller in your cluster, the rule will be using `tiller_namespace` attribute value.
+To look up for any installed tiller in your cluster, the rule will use `tiller_namespace` attribute value.
 
-You can force the use of helm v2 with `helm_v2` (set to `True`, default `False`).
+You can force the use of helm v2 using `helm_v2` attribute (set to `True`, default `False`).
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ There are three defined rules, `helm_chart` , `helm_push` and `helm_release`.
 
 These rules generate new helm packages with specific values for each development version of your application and push generated helm packages to a provided [helm chart museum](https://chartmuseum.com/).
 
+### Important notes
+
+Helm v3 is now supported.
+
+`helm_release` rule will check if tiller is installed in your cluster to decide which version of helm to use (v2 or v3).
+If the rule can't find in your cluster any deployed tiller, it will use helm v3 by default.
+To find up if you have running tiller in your cluster, the rule will be using `tiller_namespace` attribute value.
+
+You can force the use of helm v2 with `helm_v2` (set to `True`, default `False`).
+
 ### Getting started
 
 In your Bazel `WORKSPACE` file add this repository as a dependency:
@@ -211,7 +221,7 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | values_yaml | no | - | Several values files can be passed when installing release |
 | secrets_yaml | no | - | Several values files encryopted can be passed when installing release. **IMPORTANT: It requires `helm secrets` plugin to be installed and also define `sops_yaml` for sops configuration**  |
 | sops_yaml | no | - | Provide when using `secrets_yaml`. Check  https://github.com/futuresimple/helm-secrets documentation for further information |
-
+| helm_v2 | no | False | Force the use of helm v2 to deploy the release |
 
 
 ## K8s rules

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ These rules generate new helm packages with specific values for each development
 Helm v3 is now supported.
 
 `helm_release` rule will check if tiller is installed in your cluster to decide which version of helm to use (v2 or v3).
-If the rule can't find in your cluster any deployed tiller, it will use helm v3 by default.
+If the rule can't find any deployed tiller in your cluster, it will use helm v3 by default.
 To find up if you have running tiller in your cluster, the rule will be using `tiller_namespace` attribute value.
 
 You can force the use of helm v2 with `helm_v2` (set to `True`, default `False`).

--- a/examples/base-package/BUILD
+++ b/examples/base-package/BUILD
@@ -18,5 +18,5 @@ helm_release(
   name = "base_release",
   chart = ":base_package",
   namespace = "examples",
-  release_name = "base-release"
+  release_name = "base-release",
 )

--- a/examples/base-package/BUILD
+++ b/examples/base-package/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//helm:helm-chart-package.bzl", "helm_chart")
+load("//helm:helm-release.bzl", "helm_release")
 
 helm_chart(
   name = "base_package",
@@ -11,4 +12,11 @@ helm_chart(
   package_name = "base-package",
   values_tag_yaml_path = "image.tag",
   values_repo_yaml_path = "image.repository",
+)
+
+helm_release(
+  name = "base_release",
+  chart = ":base_package",
+  namespace = "examples",
+  release_name = "base-release"
 )

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -29,8 +29,9 @@ def _helm_release_impl(ctx):
     helm_path = helm_binary[0].path
     helm3_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/helm-3:toolchain_type"].helminfo.tool.files.to_list()
     helm3_path = helm3_binary[0].path
-    kubectl_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type"].kubectlingo.tool.files.to_list()
-    kubectl_path = kubcetl_binary[0].path
+    kubectl_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type"].kubectlinfo.tool.files.to_list()
+    kubectl_path = kubectl_binary[0].path
+
     chart = ctx.file.chart
     namespace = ctx.attr.namespace
     tiller_namespace = ctx.attr.tiller_namespace
@@ -90,7 +91,7 @@ helm_release = rule(
     attrs = {
       "chart": attr.label(allow_single_file = True, mandatory = True),
       "namespace": attr.string(mandatory = True, default = "default"),
-      "tiller_namespace": attr.string(mandatory = True, default = "tiller-system"),
+      "tiller_namespace": attr.string(mandatory = False, default = "tiller-system"),
       "release_name": attr.string(mandatory = True),
       "values_yaml": attr.label_list(allow_files = True, mandatory = False),
       "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -36,6 +36,7 @@ def _helm_release_impl(ctx):
     namespace = ctx.attr.namespace
     tiller_namespace = ctx.attr.tiller_namespace
     release_name = ctx.attr.release_name
+    force_helm_v2 = ctx.attr.helm_v2 or False
 
     stamp_files = [ctx.info_file, ctx.version_file]
 
@@ -66,6 +67,7 @@ def _helm_release_impl(ctx):
             "{HELM_PATH}": helm_path,
             "{HELM3_PATH}": helm3_path,
             "{KUBECTL_PATH}": kubectl_path,
+            "{FORCE_HELM_V2}": str(force_helm_v2),
             "{SECRETS_YAML}": secrets_yaml,
             "%{stamp_statements}": "\n".join([
               "\tread_variables %s" % runfile(ctx, f)
@@ -96,6 +98,7 @@ helm_release = rule(
       "values_yaml": attr.label_list(allow_files = True, mandatory = False),
       "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
       "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
+      "helm_v2": attr.bool(mandatory = False, default = False),
       "_script_template": attr.label(allow_single_file = True, default = ":helm-release.sh.tpl"),
     },
     doc = "Installs or upgrades a new helm release",

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -29,10 +29,9 @@ function read_variables() {
 
 %{stamp_statements}
 
-TILLER_PODS=$({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l)
+# Check if tiller is running inside the cluster to guess which version of helm have to run
+if [ $({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l) -ge 1 ]; then
 
-
-if [ $TILLER_PODS -ge 1]; then
     # tiller pods were found, we will use helm 2 to make the release
     echo "Using helm v2 to deploy the {RELEASE_NAME} release"
 

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -29,9 +29,10 @@ function read_variables() {
 
 %{stamp_statements}
 
-# Check if tiller is running inside the cluster to guess which version of helm have to run
-if [ $({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l) -ge 1 ]; then
+FORCE_HELM_V2={FORCE_HELM_V2}
 
+# Check if tiller is running inside the cluster to guess which version of helm have to run
+if ([ "$FORCE_HELM_V2" == "True" ] || [ $({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l) -ge 1 ]); then
     # tiller pods were found, we will use helm 2 to make the release
     echo "Using helm v2 to deploy the {RELEASE_NAME} release"
 

--- a/kubectl.BUILD
+++ b/kubectl.BUILD
@@ -1,6 +1,0 @@
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "kubectl",
-    srcs = "kubectl"
-)

--- a/kubectl.BUILD
+++ b/kubectl.BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "kubectl",
+    srcs = "kubectl"
+)

--- a/repositories/helm_repositories.bzl
+++ b/repositories/helm_repositories.bzl
@@ -28,3 +28,17 @@ def helm_repositories():
     urls = ["https://get.helm.sh/helm-v2.13.0-linux-amd64.tar.gz"],
     build_file = "@com_github_masmovil_bazel_rules//:helm.BUILD",
   )
+
+  http_archive(
+    name = "helm_v3.1.0_darwin",
+    sha256 = "aacb6ce8ffa08eebc4e4a570226675f53963c86feb8386d46abf4b8871066c92",
+    urls = ["https://get.helm.sh/helm-v3.1.0-darwin-amd64.tar.gz"],
+    build_file = "@com_github_masmovil_bazel_rules//:helm.BUILD",
+  )
+
+  http_archive(
+    name = "helm_v3.1.0_linux",
+    sha256 = "f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de",
+    urls = ["https://get.helm.sh/helm-v3.1.0-linux-amd64.tar.gz"],
+    build_file = "@com_github_masmovil_bazel_rules//:helm.BUILD",
+  )

--- a/repositories/kubectl_repositories.bzl
+++ b/repositories/kubectl_repositories.bzl
@@ -1,0 +1,16 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def kubectl_repositories():
+  http_archive(
+    name = "kubectl_darwin",
+    # sha256 = "aacb6ce8ffa08eebc4e4a570226675f53963c86feb8386d46abf4b8871066c92",
+    urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/darwin/amd64/kubectl"],
+    build_file = "@com_github_masmovil_bazel_rules//:kubectl.BUILD",
+  )
+
+  http_archive(
+    name = "kubectl_linux",
+    # sha256 = "f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de",
+    urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl"],
+    build_file = "@com_github_masmovil_bazel_rules//:kubectl.BUILD",
+  )

--- a/repositories/kubectl_repositories.bzl
+++ b/repositories/kubectl_repositories.bzl
@@ -1,16 +1,16 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def kubectl_repositories():
-  http_archive(
+  http_file(
     name = "kubectl_darwin",
-    # sha256 = "aacb6ce8ffa08eebc4e4a570226675f53963c86feb8386d46abf4b8871066c92",
+    sha256 = "9b45260bb16f251cf2bb4b4c5f90bc847ab752c9c936b784dc2bae892e10205a",
     urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/darwin/amd64/kubectl"],
-    build_file = "@com_github_masmovil_bazel_rules//:kubectl.BUILD",
+    executable = True
   )
 
-  http_archive(
+  http_file(
     name = "kubectl_linux",
     # sha256 = "f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de",
     urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl"],
-    build_file = "@com_github_masmovil_bazel_rules//:kubectl.BUILD",
+    executable = True
   )

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -23,6 +23,8 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/helm-2-16:helm_v2.16.1__osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.1.0_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.1.0__osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_linux_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_osx_toolchain",
   )
 
   # ============================== Docker repositories ==============================

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,11 +1,13 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@com_github_masmovil_bazel_rules//repositories:helm_repositories.bzl", "helm_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:yq_repositories.bzl", "yq_repositories")
+load("@com_github_masmovil_bazel_rules//repositories:kubectl_repositories.bzl", "kubectl_repositories")
 
 def repositories():
   """Download dependencies of container rules."""
   excludes = native.existing_rules().keys()
 
+  kubectl_repositories()
   helm_repositories()
   yq_repositories()
 
@@ -19,6 +21,8 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/helm:helm_v2.13.0_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/helm-2-16:helm_v2.16.1_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/helm-2-16:helm_v2.16.1__osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.1.0_linux_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.1.0__osx_toolchain",
   )
 
   # ============================== Docker repositories ==============================

--- a/toolchains/helm-3/BUILD
+++ b/toolchains/helm-3/BUILD
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:private"])
+
+load("//toolchains/helm:helm_toolchain.bzl", "helm_toolchain")
+
+toolchain_type(name = "toolchain_type")
+
+# Helm toolchain that points to helm binary version 3
+helm_toolchain(
+    name = "helm_v3.1.0_darwin",
+    tool = "@helm_v3.1.0_darwin//:helm",
+    helm_version = "3.1.0",
+    visibility = ["//visibility:public"],
+)
+
+helm_toolchain(
+    name = "helm_v3.1.0_linux",
+    tool = "@helm_v3.1.0_linux//:helm",
+    helm_version = "3.1.0",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "helm_v3.1.0_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":helm_v3.1.0_linux",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "helm_v3.1.0__osx_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:osx",
+    ],
+    toolchain = ":helm_v3.1.0_darwin",
+    toolchain_type = ":toolchain_type",
+)

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -5,13 +5,13 @@ load(":kubectl_toolchain.bzl", "kubectl_toolchain")
 toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
 
 # Helm toolchain that points to helm binary version 2.13.0
-helm_toolchain(
+kubectl_toolchain(
     name = "kubectl_darwin",
-    tool = "@kubectl_darwin//:kubectl",
+    tool = "@kubectl_darwin//file",
     visibility = ["//visibility:public"],
 )
 
-helm_toolchain(
+kubectl_toolchain(
     name = "kubectl_linux",
     tool = "@kubectl_linux//:kubectl",
     visibility = ["//visibility:public"],

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -1,0 +1,41 @@
+package(default_visibility = ["//visibility:private"])
+
+load(":kubectl_toolchain.bzl", "kubectl_toolchain")
+
+toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+
+# Helm toolchain that points to helm binary version 2.13.0
+helm_toolchain(
+    name = "kubectl_darwin",
+    tool = "@kubectl_darwin//:kubectl",
+    visibility = ["//visibility:public"],
+)
+
+helm_toolchain(
+    name = "kubectl_linux",
+    tool = "@kubectl_linux//:kubectl",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "kubectl_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":kubectl_linux",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "kubectl_osx_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:osx",
+    ],
+    toolchain = ":kubectl_darwin",
+    toolchain_type = ":toolchain_type",
+)

--- a/toolchains/kubectl/kubectl_toolchain.bzl
+++ b/toolchains/kubectl/kubectl_toolchain.bzl
@@ -1,0 +1,21 @@
+KubectlToolchainInfo = provider(
+    doc = "Kubectl toolchain",
+    fields = {
+        "tool": "Kubectl executable binary"
+    },
+)
+
+def _kubectl_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        kubectlinfo = KubectlToolchainInfo(
+            tool = ctx.attr.tool
+        ),
+    )
+    return [toolchain_info]
+
+kubectl_toolchain = rule(
+    implementation = _kubectl_toolchain_impl,
+    attrs = {
+        "tool": attr.label(allow_single_file = True),
+    },
+)


### PR DESCRIPTION
Added `kubectl` and `helm v3` toolchains.
Check if tiller pods are running in TILLER_NAMESPACE to run helm v2 or helm v3.

