### PR TITLE
fature: support secrets decrypt using sops

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ load("@com_github_masmovil_bazel_rules//sops:sops.bzl", "sops_decrypt")
 
 ### sops_decrypt
 
-You can decrypt as many secrets as you want using `sops_decrypt` rule. Use the rule attribute `src` to provide the encrypted secrets you want to decrypt.
+You can decrypt as many secrets as you want using `sops_decrypt` rule. Use the rule attribute `src` to provide the encrypted secrets that you want to decrypt.
 The rule also needs the sops config file with the keyring id in order to decrypt files (`.sops.yaml`). You can provide it using the `sops_yaml` rule attribute.
 
 Example of use:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo implements the following bazel rules:
  `helm_chart`
  `helm_push`
  `helm_release`
+ `sops_decrypt`
  `k8s_namespace`
 
 ## Documentation
@@ -194,6 +195,56 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | values_yaml | no | - | Several values files can be passed when installing release |
 | helm_version | no | "" | Force the use of helm v2 or v3 to deploy the release. The attribute can be set to **v2** or **v3** |
 
+
+## Sops rules
+Decrypting secrets using [sops](https://github.com/mozilla/sops) is now supported.
+
+To install `sops_decrypt` rule, import in your `BUILD.bazel`
+
+```python
+load("@com_github_masmovil_bazel_rules//sops:sops.bzl", "sops_decrypt")
+```
+
+### sops_decrypt
+
+You can decrypt as many secrets as you want using `sops_decrypt` rule. Use the rule attribute `src` to provide the encrypted secrets you want to decrypt.
+The rule also needs the sops config file with the keyring id in order to decrypt files (`.sops.yaml`). You can provide it using the `sops_yaml` rule attribute.
+
+Example of use:
+```python
+sops_decrypt(
+    name = "decrypt_secret_files",
+    srcs = [":secrets.yaml"]
+    sops_yaml = ":.sops.yaml"
+)
+```
+
+The following attributes are accepted by the rule (some of them are mandatory).
+
+|  Attribute | Mandatory| Default | Notes |
+| ---------- | --- | ------ | -------------- |
+| src | yes | - | One or more labels pointing to the secret files to decrypt. It accepts a glob pattern. |
+| sops_yaml | yes | - | One label referencing the `.sops.yaml` yaml with the sops config.
+
+The output of the rule are the decrypted secrets that you can pass to `helm_release`.
+
+Example of use:
+```python
+sops_decrypt(
+    name = "decrypt_secret_files",
+    srcs = [":secrets.yaml"]
+    sops_yaml = ":.sops.yaml"
+)
+
+helm_release(
+    name = "chart_install",
+    chart = ":chart",
+    namespace = "myapp",
+    tiller_namespace = "tiller-system",
+    release_name = "release-name",
+    values_yaml = glob(["charts/myapp/values.yaml"]) + [":decrypt_secret_files"]
+)
+```
 
 ## K8s rules
 

--- a/README.md
+++ b/README.md
@@ -219,12 +219,16 @@ sops_decrypt(
 )
 ```
 
+You can specify which provider integration you want to use (gcp KMS, azure key vault etc.) through the `provider` attribute.
+* For the moment only gcp KMS is supported
+
 The following attributes are accepted by the rule (some of them are mandatory).
 
 |  Attribute | Mandatory| Default | Notes |
 | ---------- | --- | ------ | -------------- |
 | src | yes | - | One or more labels pointing to the secret files to decrypt. It accepts a glob pattern. |
-| sops_yaml | yes | - | One label referencing the `.sops.yaml` yaml with the sops config.
+| sops_yaml | yes | - | One label referencing the `.sops.yaml` yaml with the sops config. |
+| provider | false | "gcp_kms" | The provider integration used to decrypt/encrypt the secrets. |
 
 The output of the rule are the decrypted secrets that you can pass to `helm_release`.
 

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -44,13 +44,6 @@ def _helm_release_impl(ctx):
     for i, values_yaml_file in enumerate(ctx.files.values_yaml):
         values_yaml = values_yaml + " -f " + values_yaml_file.short_path
 
-    secrets_yaml = ""
-    for i, secrets_yaml_file in enumerate(ctx.files.secrets_yaml):
-        secrets_yaml = secrets_yaml + " -f " + secrets_yaml_file.path
-
-    if secrets_yaml != "" and not ctx.file.sops_yaml:
-        fail(msg='sops_yaml must be provided if secrets_yaml is set')
-
     exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")
 
     # Generates the exec bash file with the provided substitutions
@@ -68,7 +61,6 @@ def _helm_release_impl(ctx):
             "{HELM3_PATH}": helm3_path,
             "{KUBECTL_PATH}": kubectl_path,
             "{FORCE_HELM_VERSION}": helm_version,
-            "{SECRETS_YAML}": secrets_yaml,
             "%{stamp_statements}": "\n".join([
               "\tread_variables %s" % runfile(ctx, f)
               for f in stamp_files]),

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -42,7 +42,7 @@ def _helm_release_impl(ctx):
 
     values_yaml = ""
     for i, values_yaml_file in enumerate(ctx.files.values_yaml):
-        values_yaml = values_yaml + " -f " + values_yaml_file.path
+        values_yaml = values_yaml + " -f " + values_yaml_file.short_path
 
     secrets_yaml = ""
     for i, secrets_yaml_file in enumerate(ctx.files.secrets_yaml):

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -38,20 +38,14 @@ if [ "$FORCE_HELM_VERSION" == "v2" ] || ( [ "$FORCE_HELM_VERSION" != "v3" ] && [
 
     {HELM_PATH} init -c
 
-    if [ "{SECRETS_YAML}" != "" ]; then
-        {HELM_PATH} secrets upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
-    else
-        {HELM_PATH} upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
-    fi
+    {HELM_PATH} upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
+
 else
     # tiller pods were not found, we will use helm 3 to make the release
     echo "Using helm v3 to deploy the {RELEASE_NAME} release"
 
     {KUBECTL_PATH} create namespace {NAMESPACE} 2> /dev/null || true
 
-    if [ "{SECRETS_YAML}" != "" ]; then
-        {HELM3_PATH} secrets upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
-    else
-        {HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
-    fi
+    echo "{HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}"
+    {HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
 fi

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -39,7 +39,7 @@ if [ "$FORCE_HELM_VERSION" == "v2" ] || ( [ "$FORCE_HELM_VERSION" != "v3" ] && [
     {HELM_PATH} init -c
 
     if [ "{SECRETS_YAML}" != "" ]; then
-        {HELM_PATH} secrets upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {SECRETS_YAML} {RELEASE_NAME} {CHART_PATH}
+        {HELM_PATH} secrets upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
     else
         {HELM_PATH} upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
     fi
@@ -50,7 +50,7 @@ else
     {KUBECTL_PATH} create namespace {NAMESPACE} 2> /dev/null || true
 
     if [ "{SECRETS_YAML}" != "" ]; then
-        {HELM3_PATH} secrets upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML} {SECRETS_YAML}
+        {HELM3_PATH} secrets upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
     else
         {HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
     fi

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -2,6 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@com_github_masmovil_bazel_rules//repositories:helm_repositories.bzl", "helm_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:yq_repositories.bzl", "yq_repositories")
 load("@com_github_masmovil_bazel_rules//repositories:kubectl_repositories.bzl", "kubectl_repositories")
+load("@com_github_masmovil_bazel_rules//repositories:sops_repositories.bzl", "sops_repositories")
 
 def repositories():
   """Download dependencies of container rules."""
@@ -10,6 +11,7 @@ def repositories():
   kubectl_repositories()
   helm_repositories()
   yq_repositories()
+  sops_repositories()
 
   native.register_toolchains(
     # Register the default docker toolchain that expects the 'docker'
@@ -25,4 +27,7 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.1.0__osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_linux_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_windows_toolchain"
   )

--- a/repositories/sops_repositories.bzl
+++ b/repositories/sops_repositories.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sops_repositories():
   http_file(
     name = "sops_darwin",
-    # sha256 = "9b45260bb16f251cf2bb4b4c5f90bc847ab752c9c936b784dc2bae892e10205a",
+    sha256 = "795f03364ed8499d169505021b443226b5a9ee9e8a58f560188a133870d194c9",
     urls = ["https://github.com/mozilla/sops/releases/download/v3.5.0/sops-v3.5.0.darwin"],
     executable = True
   )

--- a/repositories/sops_repositories.bzl
+++ b/repositories/sops_repositories.bzl
@@ -1,0 +1,23 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def sops_repositories():
+  http_file(
+    name = "sops_darwin",
+    # sha256 = "9b45260bb16f251cf2bb4b4c5f90bc847ab752c9c936b784dc2bae892e10205a",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.5.0/sops-v3.5.0.darwin"],
+    executable = True
+  )
+
+  http_file(
+    name = "sops_linux",
+    # sha256 = "69cfb3eeaa0b77cc4923428855acdfc9ca9786544eeaff9c21913be830869d29",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.5.0/sops-v3.5.0.linux"],
+    executable = True
+  )
+
+  http_file(
+    name = "sops_windows",
+    # sha256 = "69cfb3eeaa0b77cc4923428855acdfc9ca9786544eeaff9c21913be830869d29",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.5.0/sops-v3.5.0.exe"],
+    executable = True
+  )

--- a/sops/BUILD
+++ b/sops/BUILD
@@ -1,0 +1,3 @@
+exports_files(["sops-decrypt.sh.tpl"])
+
+package(default_visibility = ["//visibility:public"])

--- a/sops/sops-decrypt.bzl
+++ b/sops/sops-decrypt.bzl
@@ -10,11 +10,11 @@ def declare_output(ctx, f, outputs):
 
 # Load docker image providers
 def _sops_decrypt_impl(ctx):
-    """This impl. allows rerference and decrypr encrypted secrets.yaml files
+    """This impl. allows reference and decrypt secrets.yaml files using mozilla sops
     Args:
         name: A unique name for this rule.
-        srcs: Source files to include as the helm chart. Typically this will just be glob(["**"]).
-        update_deps: Whether or not to run a helm dependency update prior to packaging.
+        srcs: Array of secret files to decrypt
+        sops_yaml: Sops config file
     """
     inputs = [ctx.file.sops_yaml] + ctx.files.srcs
     outputs = []

--- a/sops/sops-decrypt.bzl
+++ b/sops/sops-decrypt.bzl
@@ -1,9 +1,6 @@
 def sopfile(ctx, f):
   """Return the sop file relative path of f."""
-  if ctx.workspace_name:
-    return ctx.workspace_name + "/" + f.short_path
-  else:
-    return f.short_path
+  return f.short_path
 
 # Load docker image providers
 def _sops_decrypt_impl(ctx):
@@ -17,10 +14,11 @@ def _sops_decrypt_impl(ctx):
     outputs = []
 
     sops = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/sops:toolchain_type"].sopsinfo.tool.files.to_list()[0].path
+    sops_yaml = ctx.file.sops_yaml.path
 
     # declare output files based on src inputs
     for i, srcfile in enumerate(ctx.files.srcs):
-      out = ctx.actions.declare_file(ctx.attr.package_name + "-" + srcfile.basename + ".dec")
+      out = ctx.actions.declare_file(srcfile.basename + ".dec")
       outputs.append(out)
 
     exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")
@@ -59,7 +57,7 @@ sops_decrypt = rule(
     implementation = _sops_decrypt_impl,
     attrs = {
       "srcs": attr.label_list(allow_files = True, mandatory = True),
-      "sops_yaml": attr.label(allow_single_file = True, default = ":.sops.yaml"),
+      "sops_yaml": attr.label(allow_single_file = True, mandatory = True),
       "_script_template": attr.label(allow_single_file = True, default = ":sops-decrypt.sh.tpl"),
     },
     toolchains = [

--- a/sops/sops-decrypt.bzl
+++ b/sops/sops-decrypt.bzl
@@ -34,7 +34,8 @@ def _sops_decrypt_impl(ctx):
               "\tdecrypt_file %s %s" % (sopfiles(ctx, f), declare_output(ctx, f, outputs))
               for f in ctx.files.srcs]),
             "{SOPS_BINARY_PATH}": sops,
-            "{SOPS_CONFIG_FILE}": sops_yaml
+            "{SOPS_CONFIG_FILE}": sops_yaml,
+            "{SOPS_PROVIDER}": ctx.attr.provider
         }
     )
 
@@ -59,6 +60,7 @@ sops_decrypt = rule(
     attrs = {
       "srcs": attr.label_list(allow_files = True, mandatory = True),
       "sops_yaml": attr.label(allow_single_file = True, mandatory = True),
+      "provider": attr.string(default = "gcp_kms"),
       "_script_template": attr.label(allow_single_file = True, default = ":sops-decrypt.sh.tpl"),
     },
     toolchains = [

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -3,10 +3,6 @@
 set -e
 set -o pipefail
 
-if ( [ "{SOPS_PROVIDER}" == "gcp_kms" ] && [ -z $GOOGLE_APPLICATION_CREDENTIALS ] ); then
-  export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
-fi
-
 function decrypt_file() {
     {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE} > $2
 }

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+function decrypt_file() {
+    {SOPS_BINARY_PATH} -d $1 --gcp-kms {SOPS_CONFIG_FILE}
+}
+
+{DECRYPT_FILES}

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 function decrypt_file() {
-    {SOPS_BINARY_PATH} -d $1 --gcp-kms {SOPS_CONFIG_FILE}
+    {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE}
 }
 
 {DECRYPT_FILES}

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 function decrypt_file() {
-    {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE}
+    {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE} > $2
 }
 
 {DECRYPT_FILES}

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -3,6 +3,10 @@
 set -e
 set -o pipefail
 
+if ( [ "{SOPS_PROVIDER}" == "gcp_kms" ] && [ -z $GOOGLE_APPLICATION_CREDENTIALS ] ); then
+  export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
+fi
+
 function decrypt_file() {
     {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE} > $2
 }

--- a/sops/sops.bzl
+++ b/sops/sops.bzl
@@ -1,0 +1,7 @@
+
+"""Rules for manipulate sops screts."""
+
+load("//sops:sops-decrypt.bzl", _sops_decrypt = "sops_decrypt")
+
+# Explicitly re-export the functions
+sops_decrypt = _sops_decrypt

--- a/sops/sops_decrypt.bzl
+++ b/sops/sops_decrypt.bzl
@@ -1,0 +1,69 @@
+def sopfile(ctx, f):
+  """Return the sop file relative path of f."""
+  if ctx.workspace_name:
+    return ctx.workspace_name + "/" + f.short_path
+  else:
+    return f.short_path
+
+# Load docker image providers
+def _sops_decrypt_impl(ctx):
+    """This impl. allows rerference and decrypr encrypted secrets.yaml files
+    Args:
+        name: A unique name for this rule.
+        srcs: Source files to include as the helm chart. Typically this will just be glob(["**"]).
+        update_deps: Whether or not to run a helm dependency update prior to packaging.
+    """
+    inputs = [] + ctx.files.srcs
+    outputs = []
+
+    sops = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/sops:toolchain_type"].sopsinfo.tool.files.to_list()[0].path
+
+    # declare output files based on src inputs
+    for i, srcfile in enumerate(ctx.files.srcs):
+      out = ctx.actions.declare_file(ctx.attr.package_name + "-" + srcfile.basename + ".dec")
+      outputs.append(out)
+
+    exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")
+
+    # Generates the exec bash file with the provided substitutions
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = exec_file,
+        is_executable = True,
+        substitutions = {
+            "{DECRYPT_FILES}": "\n".join([
+              "\tdecrypt_file %s" % sopfile(ctx, f)
+              for f in ctx.files.srcs]),
+            "{SOPS_BINARY_PATH}": sops,
+            "{SOPS_CONFIG_FILE}": sops_yaml
+        }
+    )
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = outputs,
+        arguments = [],
+        executable = exec_file,
+        execution_requirements = {
+            "local": "1",
+        },
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(outputs)
+        )
+    ]
+
+sops_decrypt = rule(
+    implementation = _sops_decrypt_impl,
+    attrs = {
+      "srcs": attr.label_list(allow_files = True, mandatory = True),
+      "sops_yaml": attr.label(allow_single_file = True, default = ":.sops.yaml"),
+      "_script_template": attr.label(allow_single_file = True, default = ":sops-decrypt.sh.tpl"),
+    },
+    toolchains = [
+        "@com_github_masmovil_bazel_rules//toolchains/sops:toolchain_type"
+    ],
+    doc = "Runs sops decrypt to decrypt secret files",
+)

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -5,19 +5,19 @@ load(":sops_toolchain.bzl", "sops_toolchain")
 toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
 
 # Sops toolchain that points to sops binary version 3.5.0
-helm_toolchain(
+sops_toolchain(
     name = "sops_darwin",
     tool = "@sops_darwin//file",
     visibility = ["//visibility:public"],
 )
 
-helm_toolchain(
+sops_toolchain(
     name = "sops_linux",
     tool = "@sops_linux//file",
     visibility = ["//visibility:public"],
 )
 
-helm_toolchain(
+sops_toolchain(
     name = "sops_windows",
     tool = "@sops_linux//file",
     visibility = ["//visibility:public"],
@@ -47,7 +47,7 @@ toolchain(
 )
 
 toolchain(
-    name = "sops_wnidows_toolchain",
+    name = "sops_windows_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:windows",
     ],

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -1,0 +1,56 @@
+package(default_visibility = ["//visibility:private"])
+
+load(":sops_toolchain.bzl", "sops_toolchain")
+
+toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+
+# Sops toolchain that points to sops binary version 3.5.0
+helm_toolchain(
+    name = "sops_darwin",
+    tool = "@sops_darwin//file",
+    visibility = ["//visibility:public"],
+)
+
+helm_toolchain(
+    name = "sops_linux",
+    tool = "@sops_linux//file",
+    visibility = ["//visibility:public"],
+)
+
+helm_toolchain(
+    name = "sops_windows",
+    tool = "@sops_linux//file",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "sops_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":sops_linux",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "sops_osx_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:osx",
+    ],
+    toolchain = ":sops_darwin",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "sops_wnidows_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:windows",
+    ],
+    toolchain = ":sops_windows",
+    toolchain_type = ":toolchain_type",
+)

--- a/toolchains/sops/sops_toolchain.bzl
+++ b/toolchains/sops/sops_toolchain.bzl
@@ -1,0 +1,22 @@
+SopsToolchainInfo = provider(
+    doc = "Sops toolchain",
+    fields = {
+        "tool": "Sops executable binary"
+    }
+)
+
+def _sops_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        sopsinfo = SopsToolchainInfo(
+            tool = ctx.attr.tool
+        ),
+    )
+    return [toolchain_info]
+
+sops_toolchain = rule(
+    implementation = _sops_toolchain_impl,
+    attrs = {
+        "sops_version": attr.string(),
+        "tool": attr.label(allow_single_file = True),
+    },
+)


### PR DESCRIPTION
Added `sops_decrypt` rule using defined `sops` toolchain.

You can decrypt multiple secrets using this rule, and pass them to other rules (e.g `helm_release`).

It uses gcp_kms by default, but any provider could be used in the near future.

