### PR TITLE
New attribute kube_context for helm_release rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ helm_release(
     namespace_dep = ":test-namespace",
     tiller_namespace = "tiller-system",
     release_name = "release-name",
+    kube_context = "gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01",
     values_yaml = glob(["charts/myapp/values.yaml"]),
 )
 ```
@@ -223,6 +224,7 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | namespace_dep | false | - | Namespace where this release is installed to. Must be a label to a k8s_namespace rule. It takes precedence over namespace |
 | tiller_namespace | false | kube-system | Namespace where Tiller lives in the Kubernetes Cluste. It supports the use of `stamp_variables`. Unnecessary using helm v3 |
 | release_name | yes | - | Name of the Helm release. It supports the use of `stamp_variables`|
+| kube_context | no | - | Value for `--kube-context` for helm binary (defaults to `gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01`)|
 | values_yaml | no | - | Several values files can be passed when installing release |
 | helm_version | no | "" | Force the use of helm v2 or v3 to deploy the release. The attribute can be set to **v2** or **v3** |
 

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -105,7 +105,7 @@ helm_release = rule(
       "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
       "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
       "helm_version": attr.string(mandatory = False),
-      "kube_context": attr.string(mandatory = False, defaullt = "gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01"),
+      "kube_context": attr.string(mandatory = False, default = "gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01"),
       "_script_template": attr.label(allow_single_file = True, default = ":helm-release.sh.tpl"),
     },
     doc = "Installs or upgrades a new helm release",

--- a/helm/helm-release.bzl
+++ b/helm/helm-release.bzl
@@ -22,6 +22,7 @@ def _helm_release_impl(ctx):
         chart: Chart to install
         namespace: Namespace where release is installed to
         release_name: Name of the helm release
+        kube_context: Use different specific kube context (defaults to gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01)
         values_yaml: Specify values yaml to override default
         secrets_yaml: Specify sops encrypted values to override defaulrt values (need to define sops_value as well)
         sops_yaml = Sops file if secrets_yaml is provided
@@ -37,6 +38,7 @@ def _helm_release_impl(ctx):
     tiller_namespace = ctx.attr.tiller_namespace
     release_name = ctx.attr.release_name
     helm_version = ctx.attr.helm_version or ""
+    kube_context = ctx.attr.kube_context
 
     stamp_files = [ctx.info_file, ctx.version_file]
 
@@ -71,6 +73,7 @@ def _helm_release_impl(ctx):
             "{HELM3_PATH}": helm3_path,
             "{KUBECTL_PATH}": kubectl_path,
             "{FORCE_HELM_VERSION}": helm_version,
+            "{KUBE_CONTEXT}": kube_context,
             "%{stamp_statements}": "\n".join([
               "\tread_variables %s" % runfile(ctx, f)
               for f in stamp_files]),
@@ -102,6 +105,7 @@ helm_release = rule(
       "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
       "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
       "helm_version": attr.string(mandatory = False),
+      "kube_context": attr.string(mandatory = False, defaullt = "gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01"),
       "_script_template": attr.label(allow_single_file = True, default = ":helm-release.sh.tpl"),
     },
     doc = "Installs or upgrades a new helm release",

--- a/helm/helm-release.sh.tpl
+++ b/helm/helm-release.sh.tpl
@@ -38,7 +38,7 @@ if [ "$FORCE_HELM_VERSION" == "v2" ] || ( [ "$FORCE_HELM_VERSION" != "v3" ] && [
 
     {HELM_PATH} init -c
 
-    {HELM_PATH} upgrade --install --tiller-namespace {TILLER_NAMESPACE} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
+    {HELM_PATH} upgrade --install --tiller-namespace {TILLER_NAMESPACE} --kube-context {KUBE_CONTEXT} --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
 
 else
     # tiller pods were not found, we will use helm 3 to make the release
@@ -47,5 +47,5 @@ else
     {KUBECTL_PATH} create namespace {NAMESPACE} 2> /dev/null || true
 
     echo "{HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}"
-    {HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --namespace {NAMESPACE} {VALUES_YAML}
+    {HELM3_PATH} upgrade {RELEASE_NAME} {CHART_PATH} --install --kube-context {KUBE_CONTEXT} --namespace {NAMESPACE} {VALUES_YAML}
 fi

--- a/tests/charts/nginx-with-deps/BUILD
+++ b/tests/charts/nginx-with-deps/BUILD
@@ -20,5 +20,6 @@ helm_release(
   chart = ":nginx_chart_with_deps",
   namespace = "test-nginx-with-deps",
   release_name = "test-nginx-with-deps",
-  tiller_namespace = "tiller-system"
+  tiller_namespace = "tiller-system",
+  kube_context = "kind-bazel-tillerless"
 )

--- a/tests/charts/nginx/BUILD
+++ b/tests/charts/nginx/BUILD
@@ -95,6 +95,7 @@ helm_release(
   namespace = "test-nginx-sops",
   release_name = "test-nginx-sops",
   tiller_namespace = "tiller-system",
+  kube_context = "kind-bazel-tillerless",
   values_yaml = [":sops"]
 )
 


### PR DESCRIPTION
Be able to define specific `--kube-context` rather than using current context.
It defaults to `gke_mm-k8s-dev-01_europe-west1_mm-k8s-dev-01` to always install in dev cluster in case no context has been set as attribute.