### PR TITLE
Added Google Cloud Storage upload rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,36 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | gcp_sa | no | - | GCP Service Account. I.E.  `my-account@my-project.iam.gserviceaccount.com`|
 | gcp_gke_project | no | - | GKE Project |
 | workload_identity_namespace | no | - | Workload Identity Namespace. I.E. `mm-k8s-dev-01.svc.id.goog` |
+
+
+## GCS rules
+
+Import in your `BUILD.bazel`
+
+```python
+load("@com_github_masmovil_bazel_rules//gcs:gcs.bzl", "gcs_upload")
+
+```
+
+**Gcloud SDK** is required in the system PATH.
+
+### gcs_upload
+
+`gcs_upload` is used to upload a single file to a Google Cloud Storage bucket
+
+Example of use:
+```python
+gcs_upload(
+    name = "push",
+    src = ":file",
+    destination = "gs://my-bucket/file.zip"
+)
+```
+
+
+The following attributes are accepted by the rule (some of them are mandatory).
+
+|  Attribute | Mandatory| Default | Notes |
+| ---------- | --- | ------ | -------------- |
+| src | yes | - | Source file label |
+| destination | yes | - | Destination path in GCS (in form of`gs://mybucket/file`) It supports the use of `stamp_variables`. |

--- a/gcs/BUILD
+++ b/gcs/BUILD
@@ -1,0 +1,3 @@
+
+exports_files(["gcs-upload.sh.tpl"])
+package(default_visibility = ["//visibility:public"])

--- a/gcs/gcs-upload.bzl
+++ b/gcs/gcs-upload.bzl
@@ -1,0 +1,63 @@
+load("//helpers:helpers.bzl", "write_sh", "get_make_value_or_default")
+
+def runfile(ctx, f):
+  """Return the runfiles relative path of f."""
+  if ctx.workspace_name:
+    return ctx.workspace_name + "/" + f.short_path
+  else:
+    return f.short_path
+
+def _gcs_upload_impl(ctx):
+    """Push an artifact to Google Cloud Storage
+    Args:
+        name: A unique name for this rule.
+        src: Source file to upload.
+        destination: Destination. Example: gs://my-bucket/file
+    """
+
+    src_file = ctx.file.src
+
+    # get chart museum basic auth credentials
+    destination = ctx.attr.destination
+
+    exec_file = ctx.actions.declare_file(ctx.label.name + "_gcs_upload_bash")
+
+    stamp_files = [ctx.info_file, ctx.version_file]
+
+    # Generates the exec bash file with the provided substitutions
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = exec_file,
+        is_executable = True,
+        substitutions = {
+            "{SRC_FILE}": src_file.short_path,
+            "{DESTINATION}": destination,
+            "%{stamp_statements}": "\n".join([
+              "read_variables %s" % runfile(ctx, f)
+              for f in stamp_files]),
+        }
+    )
+
+    
+
+
+    runfiles = ctx.runfiles(
+        files = [ctx.info_file, ctx.version_file, src_file]
+    )
+
+    return [DefaultInfo(
+      executable = exec_file,
+      runfiles = runfiles,
+    )]
+
+gcs_upload = rule(
+    implementation = _gcs_upload_impl,
+    attrs = {
+      "src": attr.label(allow_single_file = True, mandatory = True),
+      "destination": attr.string(mandatory = True),
+      "_script_template": attr.label(allow_single_file = True, default = ":gcs-upload.sh.tpl"),
+    },
+    doc = "Upload a file to a Google Cloud Storage Bucket",
+    toolchains = [],
+    executable = True,
+)

--- a/gcs/gcs-upload.sh.tpl
+++ b/gcs/gcs-upload.sh.tpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+function guess_runfiles() {
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_files')"
+
+function read_variables() {
+    local file="${RUNFILES}/$1"
+    local new_file="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_new')"
+    echo "${new_file}" >> "${TEMP_FILES}"
+
+    # Rewrite the file from Bazel for the form FOO=...
+    # to a form suitable for sourcing into bash to expose
+    # these variables as substitutions in the tag statements.
+    sed -E "s/^([^ ]+) (.*)\$/export \\1='\\2'/g" < ${file} > ${new_file}
+    source ${new_file}
+}
+
+%{stamp_statements}
+
+gsutil cp {SRC_FILE} {DESTINATION}
+

--- a/gcs/gcs.bzl
+++ b/gcs/gcs.bzl
@@ -1,0 +1,7 @@
+"""Rules GCS."""
+
+load("//gcs:gcs-upload.bzl", _gcs_upload = "gcs_upload")
+
+
+# Explicitly re-export the functions
+gcs_upload = _gcs_upload


### PR DESCRIPTION
`gcs_upload` is used to upload a single file to a Google Cloud Storage bucket.


Example of use:
```python
gcs_upload(
    name = "push",
    src = ":file",
    destination = "gs://my-bucket/file.zip"
)
```


The following attributes are accepted by the rule (some of them are mandatory).

|  Attribute | Mandatory| Default | Notes |
| ---------- | --- | ------ | -------------- |
| src | yes | - | Source file label |
| destination | yes | - | Destination path in GCS (in form of`gs://mybucket/file`) It supports the use of `stamp_variables`. |

