### PR TITLE
Remove temp working dir after packaging

### DIFF
--- a/helm/helm-chart-package.sh.tpl
+++ b/helm/helm-chart-package.sh.tpl
@@ -83,4 +83,6 @@ fi
 
 mv {PACKAGE_OUTPUT_PATH}/{HELM_CHART_NAME}-$HELM_CHART_VERSION.tgz {PACKAGE_OUTPUT_PATH}/{HELM_CHART_NAME}.tgz
 
+rm -rf {CHART_PATH}
+
 echo "Successfully packaged chart and saved it to: {PACKAGE_OUTPUT_PATH}/{HELM_CHART_NAME}.tgz"


### PR DESCRIPTION
Deleted source yaml files will still get included because of obsolete cached files in the temp working dir. Removing this ensure newly built templates only contains up-to-date files.