### PR TITLE
feat: add additional templates to helm_chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following attributes are accepted by the rule (some of them are mandatory).
 | values_repo_yaml_path | no | `image.repository` | The yaml path (expressed in dot notation) of values.yaml where the key of the image repository is defined in the values.yaml. |
 | values_tag_yaml_path | no | `image.tag` | The yaml path (expressed in dot notation) of values.yaml where the key of the image tag is defined in the values.yaml |
 | chart_deps | no | - | Helm chart dependencies of this rules. Defined as a list of dependencies of other helm_chart rules (bazel targets). |
+| additional_templates | no | [] | List of labels or files to be added to the `templates/` folder of the chart. Useful for centralizing common templates and pass them around different charts. |
 
 
 #### Use of make_variables

--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -4,8 +4,7 @@ load(
     "ImageInfo",
     "LayerInfo",
 )
-
-load("//helpers:helpers.bzl", "write_sh", "get_make_value_or_default")
+load("//helpers:helpers.bzl", "get_make_value_or_default", "write_sh")
 
 ChartInfo = provider(fields = [
     "chart",
@@ -124,9 +123,10 @@ def _helm_chart_impl(ctx):
             "{VALUES_REPO_YAML_PATH}": ctx.attr.values_repo_yaml_path,
             "{VALUES_TAG_YAML_PATH}": ctx.attr.values_tag_yaml_path,
             "%{stamp_statements}": "\n".join([
-              "\tread_variables %s" % f.path
-              for f in stamp_files]),
-        }
+                "\tread_variables %s" % f.path
+                for f in stamp_files
+            ]),
+        },
     )
 
     ctx.actions.run(
@@ -137,30 +137,30 @@ def _helm_chart_impl(ctx):
         execution_requirements = {
             "local": "1",
             "no-remote-exec": "1",
-            "no-remote": "1"
+            "no-remote": "1",
         },
     )
 
     return [
         DefaultInfo(
-            files = depset([targz])
-        )
+            files = depset([targz]),
+        ),
     ]
 
 helm_chart = rule(
     implementation = _helm_chart_impl,
     attrs = {
-      "srcs": attr.label_list(allow_files = True, mandatory = True),
-      "image": attr.label(allow_single_file = True, mandatory = False),
-      "image_tag": attr.string(mandatory = False),
-      "package_name": attr.string(mandatory = True),
-      "helm_chart_version": attr.string(mandatory = False, default = "1.0.0"),
-      "app_version": attr.string(mandatory = False),
-      "image_repository": attr.string(),
-      "values_repo_yaml_path": attr.string(default = "image.repository"),
-      "values_tag_yaml_path": attr.string(default = "image.tag"),
-      "_script_template": attr.label(allow_single_file = True, default = ":helm-chart-package.sh.tpl"),
-      "chart_deps": attr.label_list(allow_files = True, mandatory = False),
+        "srcs": attr.label_list(allow_files = True, mandatory = True),
+        "image": attr.label(allow_single_file = True, mandatory = False),
+        "image_tag": attr.string(mandatory = False),
+        "package_name": attr.string(mandatory = True),
+        "helm_chart_version": attr.string(mandatory = False, default = "1.0.0"),
+        "app_version": attr.string(mandatory = False),
+        "image_repository": attr.string(),
+        "values_repo_yaml_path": attr.string(default = "image.repository"),
+        "values_tag_yaml_path": attr.string(default = "image.tag"),
+        "_script_template": attr.label(allow_single_file = True, default = ":helm-chart-package.sh.tpl"),
+        "chart_deps": attr.label_list(allow_files = True, mandatory = False),
     },
     toolchains = [
         "@com_github_masmovil_bazel_rules//toolchains/yq:toolchain_type",

--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -98,6 +98,8 @@ def _helm_chart_impl(ctx):
 
     additional_templates = ctx.attr.additional_templates or []
 
+    # Copy additional templates to the "templates/" folder of the chart being assembled.
+    # This is useful for centralizing common templates and pass them to multiple charts.
     for template in additional_templates:
         for file in template.files.to_list():
             out = ctx.actions.declare_file(tmp_working_dir + "/" + chart_root_path + "/templates/" + file.basename)


### PR DESCRIPTION
Hello folks 👋🏻   
First off, love the work you've being doing here 💯 

In our usecase, we have a list of common Helm templates that are shared across all of our charts. I didn't see this option in `helm_chart` so I thought I'd add it.

This PR introduces an additional attribute, called `additional_templates`, to specify such targets. The targets will be copied under the `templates/` folder before packing the chart in a tarball.