### PR TITLE
chore: update yq to 4.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ helm_chart(
   srcs = glob(["**"]),
   image  = "//docker/flex:flex", // Reference to the docker image rule to extract the digest sha256 from
   package_name = "flex", // name of the helm package. This will be the name of the generated tar.gz helm package
-  values_tag_yaml_path = "base.k8s.deployment.image.tag", // yaml Path of the image tag in the values.yaml files
+  values_tag_yaml_path = ".base.k8s.deployment.image.tag", // yaml Path of the image tag in the values.yaml files
   helm_chart_version = "0.1.1"
 )
 ```

--- a/examples/base-package/BUILD
+++ b/examples/base-package/BUILD
@@ -11,7 +11,7 @@ helm_chart(
   helm_chart_version = "1.0.0",
   package_name = "base-package",
   values_tag_yaml_path = ".image.tag",
-  values_repo_yaml_path = "limage.repository",
+  values_repo_yaml_path = ".image.repository",
 )
 
 helm_release(

--- a/examples/base-package/BUILD
+++ b/examples/base-package/BUILD
@@ -10,8 +10,8 @@ helm_chart(
   image_repository  = "gcr.io/lab/base-replaced-by-rule-image-url",
   helm_chart_version = "1.0.0",
   package_name = "base-package",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository",
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = "limage.repository",
 )
 
 helm_release(

--- a/examples/deps-bazel-rules-example/BUILD
+++ b/examples/deps-bazel-rules-example/BUILD
@@ -9,7 +9,7 @@ helm_chart(
   image_repository  = "gcr.io/lab/package-image-url",
   helm_chart_version = "1.0.0",
   package_name = "deps-bazel-rules-example",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository",
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository",
   chart_deps = ["//examples/base-package:base_package"]
 )

--- a/helm/helm-chart-package.sh.tpl
+++ b/helm/helm-chart-package.sh.tpl
@@ -39,13 +39,13 @@ if  [ -z $DIGEST_PATH ]; then
 
     # Image repository is provided as a static value
     if [ "$IMAGE_REPOSITORY" != "" ] && [ -n $IMAGE_REPOSITORY ]; then
-        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH} $IMAGE_REPOSITORY
+        {YQ_PATH} e "{VALUES_REPO_YAML_PATH} = \"$IMAGE_REPOSITORY\"" -i {CHART_VALUES_PATH}
         echo "Replaced image repository in chart values.yaml with: $IMAGE_REPOSITORY"
     fi
 
     # Image tag is provided as a static value
     if [ "$IMAGE_TAG" != "" ] && [ -n $IMAGE_TAG ]; then
-        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $IMAGE_TAG
+        {YQ_PATH} e "{VALUES_TAG_YAML_PATH} = \"$IMAGE_TAG\"" -i {CHART_VALUES_PATH}
         echo "Replaced image tag in chart values.yaml with: $IMAGE_TAG"
     fi
 
@@ -58,7 +58,7 @@ if [ -n $DIGEST_PATH ] && [ "$DIGEST_PATH" != "" ]; then
     IFS=':' read -ra digest_split <<< "$DIGEST"
     DIGEST_SHA=${digest_split[1]}
 
-    {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_TAG_YAML_PATH} $DIGEST_SHA
+    {YQ_PATH} e "{VALUES_TAG_YAML_PATH} = \"$DIGEST_SHA\"" -i {CHART_VALUES_PATH}
 
     echo "Replaced image tag in chart values.yaml with: $DIGEST_SHA"
 
@@ -68,12 +68,12 @@ if [ -n $DIGEST_PATH ] && [ "$DIGEST_PATH" != "" ]; then
         REPO_URL="{IMAGE_REPOSITORY}"
     else
         # if image_repository attr is not provided, extract it from values.yaml
-        REPO_URL=$({YQ_PATH} r {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH})
+        REPO_URL=$({YQ_PATH} e "{VALUES_REPO_YAML_PATH}" {CHART_VALUES_PATH})
     fi
 
     # appends @sha256 suffix to image repo url value if the repository value does not already contains it
     if ([ -n $REPO_URL ] || [ -n $REPO_SUFIX ]) && ([[ $REPO_URL != *"$REPO_SUFIX" ]] || [[ -z "$REPO_SUFIX" ]]); then
-        {YQ_PATH} w -i {CHART_VALUES_PATH} {VALUES_REPO_YAML_PATH} ${REPO_URL}${REPO_SUFIX}
+        {YQ_PATH} e "{VALUES_REPO_YAML_PATH} = \"${REPO_URL}${REPO_SUFIX}\"" -i {CHART_VALUES_PATH}
     fi
 fi
 

--- a/repositories/yq_repositories.bzl
+++ b/repositories/yq_repositories.bzl
@@ -1,15 +1,18 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-def yq_repositories():
-  http_file(
-    name = "yq_v2.4.1_linux",
-    urls = ["https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64"],
-    executable = True
-  )
+yq_version = "v4.11.1"
 
-  http_file(
-    name = "yq_v2.4.1_darwin",
-    urls = ["https://github.com/mikefarah/yq/releases/download/2.4.1/yq_darwin_amd64"],
-    sha256 = "06732685917646c0bbba8cc17386cd2a39b214ad3cd128fb4b8b410ed069101c",
-    executable = True
-  )
+def yq_repositories():
+    http_file(
+        name = "yq_linux",
+        urls = ["https://github.com/mikefarah/yq/releases/download/%s/yq_linux_amd64" % yq_version],
+        sha256 = "1f63c9fe412c0d17b263e0ccfd91a596bb359db69ef7dddf5f53af1b2e8db898",
+        executable = True,
+    )
+
+    http_file(
+        name = "yq_darwin",
+        urls = ["https://github.com/mikefarah/yq/releases/download/%s/yq_darwin_amd64" % yq_version],
+        sha256 = "95244750f0d9e2bd37b48e473823cc8dacf8ccc8a69fd5bbd20fe023bfead002",
+        executable = True,
+    )

--- a/tests/charts/nginx-with-deps/BUILD
+++ b/tests/charts/nginx-with-deps/BUILD
@@ -10,8 +10,8 @@ helm_chart(
   image_repository  = "nginx",
   helm_chart_version = "1.0.0",
   package_name = "nginx-with-deps",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository",
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository",
   chart_deps = ["//tests/charts/nginx:nginx_chart"]
 )
 

--- a/tests/charts/nginx/BUILD
+++ b/tests/charts/nginx/BUILD
@@ -11,8 +11,8 @@ helm_chart(
   image_repository  = "nginx",
   helm_chart_version = "1.0.0",
   package_name = "nginx",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository"
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository"
 )
 
 helm_chart(
@@ -22,8 +22,8 @@ helm_chart(
   image_repository  = "nginx",
   helm_chart_version = "2.0.0",
   package_name = "nginx",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository"
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository"
 )
 
 helm_chart(
@@ -33,8 +33,8 @@ helm_chart(
   image_repository  = "nginx",
   helm_chart_version = "1.0.0",
   package_name = "nginx",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository"
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository"
 )
 
 helm_chart(
@@ -44,8 +44,8 @@ helm_chart(
   image_repository  = "nginx",
   helm_chart_version = "{TEST_VERSION}",
   package_name = "nginx",
-  values_tag_yaml_path = "image.tag",
-  values_repo_yaml_path = "image.repository"
+  values_tag_yaml_path = ".image.tag",
+  values_repo_yaml_path = ".image.repository"
 )
 
 helm_chart(

--- a/toolchains/yq/BUILD
+++ b/toolchains/yq/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:private"])
-
 load(":yq_toolchain.bzl", "yq_toolchain")
+
+package(default_visibility = ["//visibility:private"])
 
 toolchain_type(name = "toolchain_type")
 
@@ -8,13 +8,13 @@ toolchain_type(name = "toolchain_type")
 # to be in the PATH.
 yq_toolchain(
     name = "yq_linux",
-    tool = "@yq_v2.4.1_linux//file",
+    tool = "@yq_linux//file",
     visibility = ["//visibility:public"],
 )
 
 yq_toolchain(
     name = "yq_osx",
-    tool = "@yq_v2.4.1_darwin//file",
+    tool = "@yq_darwin//file",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Hello again folks 👋🏻 

Since I was having troubles with YAML substitution using anchors on yq 2.4.1 (previous version), I tried to update to yq 4.11.1 (latest stable release) and it solved my problems, so I thought it would be a nice idea to share 😄 

The CLI API changed quite a bit from the previous version, you can see the changes reflected in the `helm-chart-package.sh.tpl` template.

What's more, the `values_*_yaml_path` values should now use a leading dot (i.e. `.base.k8s.image.tag` instead of `base.k8s.image.tag`)