### PR TITLE
Constrained sops_osx_toolchain to cpu:x86_64

### DIFF
--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -41,6 +41,7 @@ toolchain(
     name = "sops_osx_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = ":sops_darwin",
     toolchain_type = ":toolchain_type",


### PR DESCRIPTION
SOPS currently only releases binaries for x86_64 macOS. This is incompatible w/ M1-based architecture. This will lead to clearer failures for the incompatibility rather than failing on execution.