### PR TITLE
Fix a bug where extracted dependencies dir aren't in Bazel output

### DIFF
--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -95,7 +95,7 @@ def _helm_chart_impl(ctx):
             outputs = [out, out_dir],
             inputs = dep[DefaultInfo].files,
             arguments = [dep[DefaultInfo].files.to_list()[0].path, out.path],
-            command = "cp -f $1 $2; tar -C $(dirname $2) -xzf $2",
+            command = "rm -rf $3; cp -f $1 $2; tar -C $(dirname $2) -xzf $2",
         )
 
     additional_templates = ctx.attr.additional_templates or []

--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -87,13 +87,15 @@ def _helm_chart_impl(ctx):
     # copy generated charts by other rules into temporal chart_root/charts directory (treated as a helm dependency)
     for i, dep in enumerate(deps):
         dep_files = dep[DefaultInfo].files.to_list()
-        out = ctx.actions.declare_file(tmp_working_dir + "/" + chart_root_path + "/charts/" + dep[DefaultInfo].files.to_list()[0].basename)
+        tgz = dep[DefaultInfo].files.to_list()[0]
+        out = ctx.actions.declare_file(tmp_working_dir + "/" + chart_root_path + "/charts/" + tgz.basename)
+        out_dir = ctx.actions.declare_file(tmp_working_dir + "/" + chart_root_path + "/charts/" + tgz.basename[:-len(tgz.extension) - 1])
         inputs = inputs + dep_files + [out]
         ctx.actions.run_shell(
-            outputs = [out],
+            outputs = [out, out_dir],
             inputs = dep[DefaultInfo].files,
             arguments = [dep[DefaultInfo].files.to_list()[0].path, out.path],
-            command = "cp -f $1 $2; tar -C $(dirname $2) -xzf $2",
+            command = "echo 1 && cp -f $1 $2 && ls $(dirname $2) && echo 2 && echo tar -C $(dirname $2) -xzf $2 && tar -C $(dirname $2) -xzf $2 && ls $(dirname $2)",
         )
 
     additional_templates = ctx.attr.additional_templates or []

--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -95,7 +95,7 @@ def _helm_chart_impl(ctx):
             outputs = [out, out_dir],
             inputs = dep[DefaultInfo].files,
             arguments = [dep[DefaultInfo].files.to_list()[0].path, out.path],
-            command = "echo 1 && cp -f $1 $2 && ls $(dirname $2) && echo 2 && echo tar -C $(dirname $2) -xzf $2 && tar -C $(dirname $2) -xzf $2 && ls $(dirname $2)",
+            command = "cp -f $1 $2; tar -C $(dirname $2) -xzf $2",
         )
 
     additional_templates = ctx.attr.additional_templates or []

--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -94,7 +94,7 @@ def _helm_chart_impl(ctx):
         ctx.actions.run_shell(
             outputs = [out, out_dir],
             inputs = dep[DefaultInfo].files,
-            arguments = [dep[DefaultInfo].files.to_list()[0].path, out.path],
+            arguments = [dep[DefaultInfo].files.to_list()[0].path, out.path, out_dir.path],
             command = "rm -rf $3; cp -f $1 $2; tar -C $(dirname $2) -xzf $2",
         )
 


### PR DESCRIPTION
Include extracted dependencies dir in outputs.

Fixes a bug where listed dependencies give the error "Chart.yaml not found", since the output of the `tar -xzf` command is not listed in Bazel's outputs.

Without this fix, dependencies can't be listed in the `dependencies:` section of the `Chart.yaml`.