### PR TITLE
"helm diff" and "helm lint" convenience wrappers

### DIFF
--- a/helm/BUILD
+++ b/helm/BUILD
@@ -1,3 +1,3 @@
-exports_files(["helm-chart-package.sh.tpl", "helm-release.sh.tpl"])
+exports_files(["helm-chart-package.sh.tpl", "helm-diff.sh.tpl", "helm-release.sh.tpl"])
 
 package(default_visibility = ["//visibility:public"])

--- a/helm/BUILD
+++ b/helm/BUILD
@@ -1,3 +1,3 @@
-exports_files(["helm-chart-package.sh.tpl", "helm-diff.sh.tpl", "helm-release.sh.tpl"])
+exports_files(["helm-chart-package.sh.tpl", "helm-diff.sh.tpl", "helm-lint.sh.tpl", "helm-release.sh.tpl"])
 
 package(default_visibility = ["//visibility:public"])

--- a/helm/helm-diff.bzl
+++ b/helm/helm-diff.bzl
@@ -4,23 +4,22 @@ load(
     "ImageInfo",
     "LayerInfo",
 )
-
-load("//helpers:helpers.bzl", "write_sh", "get_make_value_or_default")
+load("//helpers:helpers.bzl", "get_make_value_or_default", "write_sh")
 load("//k8s:k8s.bzl", "NamespaceDataInfo")
 
 def runfile(ctx, f):
-  """Return the runfiles relative path of f."""
-  if ctx.workspace_name:
-    return ctx.workspace_name + "/" + f.short_path
-  else:
-    return f.short_path
+    """Return the runfiles relative path of f."""
+    if ctx.workspace_name:
+        return ctx.workspace_name + "/" + f.short_path
+    else:
+        return f.short_path
 
-def _helm_release_impl(ctx):
-    """Installs or upgrades a helm release.
+def _helm_diff_impl(ctx):
+    """Executes a "helm diff" using a given chart and version
     Args:
         name: A unique name for this rule.
-        chart: Chart to install
-        namespace: Namespace where release is installed to
+        chart: Chart to reference (as new deployment)
+        namespace: Namespace where release is installed to and will be upgraded
         release_name: Name of the helm release
         values_yaml: Specify values yaml to override default
         secrets_yaml: Specify sops encrypted values to override default values (need to define sops_value as well)
@@ -34,29 +33,24 @@ def _helm_release_impl(ctx):
     kubectl_path = kubectl_binary[0].path
 
     chart = ctx.file.chart
-    force = ctx.attr.force
     tiller_namespace = ctx.attr.tiller_namespace
     release_name = ctx.attr.release_name
     helm_version = ctx.attr.helm_version or ""
     kubernetes_context = ctx.attr.kubernetes_context
-    create_namespace = ctx.attr.create_namespace
-    wait = ctx.attr.wait
-    wait_timeout = ctx.attr.wait_timeout
     stamp_files = [ctx.info_file, ctx.version_file]
 
     values_yaml = ""
     for i, values_yaml_file in enumerate(ctx.files.values_yaml):
         values_yaml = values_yaml + " -f " + values_yaml_file.short_path
 
-    exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")
+    exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_diff_bash")
 
     if ctx.attr.namespace_dep:
         namespace = ctx.attr.namespace_dep[NamespaceDataInfo].namespace
+    elif ctx.attr.namespace:
+        namespace = ctx.attr.namespace
     else:
-        if ctx.attr.namespace:
-            namespace = ctx.attr.namespace
-        else:
-            namespace = "default"
+        namespace = "default"
 
     # Generates the exec bash file with the provided substitutions
     ctx.actions.expand_template(
@@ -65,62 +59,59 @@ def _helm_release_impl(ctx):
         is_executable = True,
         substitutions = {
             "{CHART_PATH}": chart.short_path,
-            "{FORCE}": force,
             "{NAMESPACE}": namespace,
             "{TILLER_NAMESPACE}": tiller_namespace,
-            "{TIMEOUT}": wait_timeout,
             "{RELEASE_NAME}": release_name,
             "{VALUES_YAML}": values_yaml,
+            "{VERBOSE}": "echo" if ctx.attr.verbose else "true",
+            "{QUIET}": "" if ctx.attr.verbose else "--quiet",
+            "{DEBUG}": "--debug" if ctx.attr.verbose else "",
             "{HELM_PATH}": helm_path,
             "{HELM3_PATH}": helm3_path,
             "{KUBECTL_PATH}": kubectl_path,
             "{FORCE_HELM_VERSION}": helm_version,
             "{KUBERNETES_CONTEXT}": kubernetes_context,
-            "{CREATE_NAMESPACE}": create_namespace,
-            "{WAIT}": wait,
             "%{stamp_statements}": "\n".join([
-              "\tread_variables %s" % runfile(ctx, f)
-              for f in stamp_files]),
-        }
+                "\tread_variables %s" % runfile(ctx, f)
+                for f in stamp_files
+            ]),
+        },
     )
 
     runfiles = ctx.runfiles(
         files = [
             chart,
             ctx.info_file,
-            ctx.version_file
-        ] + ctx.files.values_yaml + ctx.files.secrets_yaml + ctx.files.sops_yaml + helm_binary + helm3_binary + kubectl_binary
+            ctx.version_file,
+        ] + ctx.files.values_yaml + ctx.files.secrets_yaml + ctx.files.sops_yaml + helm_binary + helm3_binary + kubectl_binary,
     )
 
     return [DefaultInfo(
-      executable = exec_file,
-      runfiles = runfiles,
+        executable = exec_file,
+        runfiles = runfiles,
     )]
 
-helm_release = rule(
-    implementation = _helm_release_impl,
+helm_diff = rule(
+    implementation = _helm_diff_impl,
     attrs = {
-      "chart": attr.label(allow_single_file = True, mandatory = True),
-      "force": attr.string(mandatory = False, default = ""),  # could actually be a boolean
-      "namespace_dep": attr.label(mandatory = False),
-      "namespace": attr.string(mandatory = False),
-      "tiller_namespace": attr.string(mandatory = False, default = "tiller-system"),
-      "release_name": attr.string(mandatory = True),
-      "values_yaml": attr.label_list(allow_files = True, mandatory = False),
-      "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
-      "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
-      "helm_version": attr.string(mandatory = False),
-      "kubernetes_context": attr.string(mandatory = False),
-      "create_namespace": attr.string(mandatory = False, default = ""),
-      "wait": attr.string(mandatory = False, default = ""),  # could actually be a boolean
-      "wait_timeout": attr.string(mandatory = False, default = ""),
-      "_script_template": attr.label(allow_single_file = True, default = ":helm-release.sh.tpl"),
+        "chart": attr.label(allow_single_file = True, mandatory = True),
+        "namespace_dep": attr.label(mandatory = False),
+        "namespace": attr.string(mandatory = False),
+        "tiller_namespace": attr.string(mandatory = False, default = "tiller-system"),
+        "release_name": attr.string(mandatory = True),
+        "values_yaml": attr.label_list(allow_files = True, mandatory = False),
+        "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
+        "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
+        "helm_version": attr.string(mandatory = False),
+        "kubernetes_context": attr.string(mandatory = False),
+        "verbose": attr.bool(mandatory = False, default = False),
+        "_script_template": attr.label(allow_single_file = True, default = ":helm-diff.sh.tpl"),
     },
     doc = "Installs or upgrades a new helm release",
     toolchains = [
         "@com_github_masmovil_bazel_rules//toolchains/helm:toolchain_type",
         "@com_github_masmovil_bazel_rules//toolchains/helm-3:toolchain_type",
-        "@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type"
+        "@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type",
     ],
     executable = True,
 )

--- a/helm/helm-diff.sh.tpl
+++ b/helm/helm-diff.sh.tpl
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+function guess_runfiles() {
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_files')"
+
+function read_variables() {
+    local file="${RUNFILES}/$1"
+    local new_file="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_new')"
+    echo "${new_file}" >> "${TEMP_FILES}"
+
+    # Rewrite the file from Bazel for the form FOO=...
+    # to a form suitable for sourcing into bash to expose
+    # these variables as substitutions in the tag statements.
+    sed -E "s/^([^ ]+) (.*)\$/export \\1='\\2'/g" < ${file} > ${new_file}
+    source ${new_file}
+}
+
+# shellcheck disable=SC1083,SC2043
+%{stamp_statements}
+
+FORCE_HELM_VERSION={FORCE_HELM_VERSION}
+
+HELM_OPTIONS="{DEBUG}"
+
+if [ "{KUBERNETES_CONTEXT}" != "" ]; then
+    HELM_OPTIONS="${HELM_OPTIONS} --kube-context {KUBERNETES_CONTEXT}"
+fi
+
+# Check if tiller is running inside the cluster to guess which version of helm have to run
+# shellcheck disable=SC1009,SC1054,SC1056,SC1072,SC1073,SC1083
+if [ "$FORCE_HELM_VERSION" == "v2" ] || ( [ "$FORCE_HELM_VERSION" != "v3" ] && [ $({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l) -ge 1 ] ); then
+    # tiller pods were found, we will use helm 2 to make the release
+    {VERBOSE} "Using helm v2 to diff the {RELEASE_NAME} release"
+    {VERBOSE} "WARNING: THIS IS UNTESTED; this might work in Helm2"
+    {VERBOSE} "We did not block the possibility but we cannot test it: helm2 is fairly rare now"
+    {VERBOSE} "Please PR any fixups you find from your testing if you still have Helm2"
+
+    {VERBOSE} "{HELM_PATH} diff upgrade --tiller-namespace {TILLER_NAMESPACE} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}"
+    {HELM_PATH} diff upgrade --tiller-namespace {TILLER_NAMESPACE} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML} {RELEASE_NAME} {CHART_PATH}
+else
+    # tiller pods were not found, we will use helm 3 to make the release
+    {VERBOSE} "Using helm v3 to diff the {RELEASE_NAME} release"
+
+    {VERBOSE} "{HELM3_PATH} diff upgrade {RELEASE_NAME} {CHART_PATH} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML}"
+    {HELM3_PATH} diff upgrade {RELEASE_NAME} {CHART_PATH} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML}
+fi

--- a/helm/helm-lint.bzl
+++ b/helm/helm-lint.bzl
@@ -1,0 +1,114 @@
+# Load docker image providers
+load(
+    "@io_bazel_rules_docker//container:providers.bzl",
+    "ImageInfo",
+    "LayerInfo",
+)
+load("//helpers:helpers.bzl", "get_make_value_or_default", "write_sh")
+load("//k8s:k8s.bzl", "NamespaceDataInfo")
+
+def runfile(ctx, f):
+    """Return the runfiles relative path of f."""
+    if ctx.workspace_name:
+        return ctx.workspace_name + "/" + f.short_path
+    else:
+        return f.short_path
+
+def _helm_lint_impl(ctx):
+    """Executes a "helm lint" using a given chart and version
+    Args:
+        name: A unique name for this rule.
+        chart: Chart to reference
+        namespace: Namespace where release is would be installed/upgraded
+        release_name: Name of the helm release
+        values_yaml: Specify values yaml to override default
+        secrets_yaml: Specify sops encrypted values to override default values (need to define sops_value as well)
+        sops_yaml = Sops file if secrets_yaml is provided
+    """
+    helm_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/helm:toolchain_type"].helminfo.tool.files.to_list()
+    helm_path = helm_binary[0].path
+    helm3_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/helm-3:toolchain_type"].helminfo.tool.files.to_list()
+    helm3_path = helm3_binary[0].path
+    kubectl_binary = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type"].kubectlinfo.tool.files.to_list()
+    kubectl_path = kubectl_binary[0].path
+
+    chart = ctx.file.chart
+    release_name = ctx.attr.release_name
+    helm_version = ctx.attr.helm_version or ""
+    kubernetes_context = ctx.attr.kubernetes_context
+    stamp_files = [ctx.info_file, ctx.version_file]
+
+    values_yaml = ""
+    for i, values_yaml_file in enumerate(ctx.files.values_yaml):
+        values_yaml = values_yaml + " -f " + values_yaml_file.short_path
+
+    exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_lint_bash")
+
+    if ctx.attr.namespace_dep:
+        namespace = ctx.attr.namespace_dep[NamespaceDataInfo].namespace
+    elif ctx.attr.namespace:
+        namespace = ctx.attr.namespace
+    else:
+        namespace = "default"
+
+    # Generates the exec bash file with the provided substitutions
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = exec_file,
+        is_executable = True,
+        substitutions = {
+            "{CHART_PATH}": chart.short_path,
+            "{NAMESPACE}": namespace,
+            "{RELEASE_NAME}": release_name,
+            "{VALUES_YAML}": values_yaml,
+            "{VERBOSE}": "echo" if ctx.attr.verbose else "true",
+            "{QUIET}": "" if ctx.attr.verbose else "--quiet",
+            "{DEBUG}": "--debug" if ctx.attr.verbose else "",
+            "{HELM_PATH}": helm_path,
+            "{HELM3_PATH}": helm3_path,
+            "{KUBECTL_PATH}": kubectl_path,
+            "{FORCE_HELM_VERSION}": helm_version,
+            "{KUBERNETES_CONTEXT}": kubernetes_context,
+            "%{stamp_statements}": "\n".join([
+                "\tread_variables %s" % runfile(ctx, f)
+                for f in stamp_files
+            ]),
+        },
+    )
+
+    runfiles = ctx.runfiles(
+        files = [
+            chart,
+            ctx.info_file,
+            ctx.version_file,
+        ] + ctx.files.values_yaml + ctx.files.secrets_yaml + ctx.files.sops_yaml + helm_binary + helm3_binary + kubectl_binary,
+    )
+
+    return [DefaultInfo(
+        executable = exec_file,
+        runfiles = runfiles,
+    )]
+
+helm_lint = rule(
+    implementation = _helm_lint_impl,
+    attrs = {
+        "chart": attr.label(allow_single_file = True, mandatory = True),
+        "namespace_dep": attr.label(mandatory = False),
+        "namespace": attr.string(mandatory = False),
+        "release_name": attr.string(mandatory = True),
+        "values_yaml": attr.label_list(allow_files = True, mandatory = False),
+        "secrets_yaml": attr.label_list(allow_files = True, mandatory = False),
+        "sops_yaml": attr.label(allow_single_file = True, mandatory = False),
+        "helm_version": attr.string(mandatory = False),
+        "kubernetes_context": attr.string(mandatory = False),
+        "verbose": attr.bool(mandatory = False, default = False),
+        "_script_template": attr.label(allow_single_file = True, default = ":helm-lint.sh.tpl"),
+    },
+    doc = "Installs or upgrades a new helm release",
+    toolchains = [
+        "@com_github_masmovil_bazel_rules//toolchains/helm:toolchain_type",
+        "@com_github_masmovil_bazel_rules//toolchains/helm-3:toolchain_type",
+        "@com_github_masmovil_bazel_rules//toolchains/kubectl:toolchain_type",
+    ],
+    executable = True,
+)

--- a/helm/helm-lint.sh.tpl
+++ b/helm/helm-lint.sh.tpl
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+function guess_runfiles() {
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_files')"
+
+function read_variables() {
+    local file="${RUNFILES}/$1"
+    local new_file="$(mktemp -t 2>/dev/null || mktemp -t 'helm_release_new')"
+    echo "${new_file}" >> "${TEMP_FILES}"
+
+    # Rewrite the file from Bazel for the form FOO=...
+    # to a form suitable for sourcing into bash to expose
+    # these variables as substitutions in the tag statements.
+    sed -E "s/^([^ ]+) (.*)\$/export \\1='\\2'/g" < ${file} > ${new_file}
+    source ${new_file}
+}
+
+# shellcheck disable=SC1083,SC2043
+%{stamp_statements}
+
+FORCE_HELM_VERSION={FORCE_HELM_VERSION}
+
+HELM_OPTIONS="{DEBUG}"
+
+if [ "{KUBERNETES_CONTEXT}" != "" ]; then
+    HELM_OPTIONS="${HELM_OPTIONS} --kube-context {KUBERNETES_CONTEXT}"
+fi
+
+# Check if tiller is running inside the cluster to guess which version of helm have to run
+# shellcheck disable=SC1009,SC1054,SC1056,SC1072,SC1073,SC1083
+if [ "$FORCE_HELM_VERSION" == "v2" ] || ( [ "$FORCE_HELM_VERSION" != "v3" ] && [ $({KUBECTL_PATH} get pods -n {TILLER_NAMESPACE} | grep tiller | wc -l) -ge 1 ] ); then
+    # tiller pods were found, we will use helm 2 to make the release
+    echo  "Using helm v2 to lint the {RELEASE_NAME} release"
+    {VERBOSE} "WARNING: THIS IS UNTESTED; this might work in Helm2"
+    {VERBOSE} "We did not block the possibility but we cannot test it: helm2 is fairly rare now"
+    {VERBOSE} "Please PR any fixups you find from your testing if you still have Helm2"
+
+    {VERBOSE} "{HELM_PATH} lint $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML} {CHART_PATH}"
+    {HELM_PATH} lint $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML} {CHART_PATH}
+else
+    # tiller pods were not found, we will use helm 3 to make the release
+    {VERBOSE}  "Using helm v3 to lint the {RELEASE_NAME} release"
+
+    {VERBOSE} "{HELM3_PATH} lint {CHART_PATH} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML}"
+    {HELM3_PATH} lint {CHART_PATH} $HELM_OPTIONS --namespace {NAMESPACE} {VALUES_YAML}
+fi

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -1,10 +1,12 @@
 """Rules for manipulation helm packages."""
 
 load("//helm:helm-chart-package.bzl", _helm_chart = "helm_chart")
+load("//helm:helm-diff.bzl", _helm_diff = "helm_diff")
 load("//helm:helm-push.bzl", _helm_push = "helm_push")
 load("//helm:helm-release.bzl", _helm_release = "helm_release")
 
 # Explicitly re-export the functions
 helm_chart = _helm_chart
+helm_diff = _helm_diff
 helm_push = _helm_push
 helm_release = _helm_release

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -2,11 +2,13 @@
 
 load("//helm:helm-chart-package.bzl", _helm_chart = "helm_chart")
 load("//helm:helm-diff.bzl", _helm_diff = "helm_diff")
+load("//helm:helm-lint.bzl", _helm_lint = "helm_lint")
 load("//helm:helm-push.bzl", _helm_push = "helm_push")
 load("//helm:helm-release.bzl", _helm_release = "helm_release")
 
 # Explicitly re-export the functions
 helm_chart = _helm_chart
 helm_diff = _helm_diff
+helm_lint = _helm_lint
 helm_push = _helm_push
 helm_release = _helm_release


### PR DESCRIPTION
Provide targets to diff and lint helmcharts -- essentially wrappers around "helm diff" and "helm lint".

We found that when upgrading charts, converging values.yaml files, refactoring, it was helpful to be able to take the "repaired" or "improved" service about to be deployed, and `helm diff` against the running service to see what the diff entails -- or prove that there is no resulting diff after a refactor.  Additionally, a `helm lint` -- also a `run` rule not as a `test` -- is a another helpful feature to ensure that avoidable problems are avoided.

In actual usage, I have a `multirun` (@com_github_atlassian_bazel_tools//multirun) that iterates my deploy environments and confirms the diff for each service (I should do that with "lint").  This has greatly accelerated refactoring to shared templates.

I wanted to share, to get this feature into maintenance so that the commit I'm carrying to customize for our environment is minimized, and so that other people may find it useful.

If desired (file an issue) I'm willing to document a demo of a "multirun diff" to show the force-multiplier of this wrapping.