### PR TITLE
Update sops to 3.7.3, permitting sops_() actions on M2 Mac

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -34,8 +34,10 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/helm-3:helm_v3.6.2_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_osx_toolchain",
-    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_linux_toolchain",
-    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_linux_amd64_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_linux_arm64_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_amd64_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_arm64_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/sops:sops_windows_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_linux_toolchain"

--- a/repositories/sops_repositories.bzl
+++ b/repositories/sops_repositories.bzl
@@ -2,22 +2,36 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def sops_repositories():
   http_file(
-    name = "sops_darwin",
-    # sha256 = "795f03364ed8499d169505021b443226b5a9ee9e8a58f560188a133870d194c9",
-    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.darwin"],
+    name = "sops_darwin_amd64",
+    sha256 = "d62c9a4404197b5e56b59a4974caeb44086dd8cc9a5dba903e949d3a0a8e1350",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.amd64"],
     executable = True
   )
 
   http_file(
-    name = "sops_linux",
-    # sha256 = "610fca9687d1326ef2e1a66699a740f5dbd5ac8130190275959da737ec52f096",
-    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux"],
+    name = "sops_darwin_arm64",
+    sha256 = "be9ce265c7f3d3b534535d2a5ef7b41600bf2b8241b1a4f95e48804d20628b2e",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.arm64"],
+    executable = True
+  )
+
+  http_file(
+    name = "sops_linux_amd64",
+    sha256 = "53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.linux.amd64"],
+    executable = True
+  )
+
+  http_file(
+    name = "sops_linux_arm64",
+    sha256 = "4945313ed0dfddba52a12ab460d750c91ead725d734039493da0285ad6c5f032",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.linux.arm64"],
     executable = True
   )
 
   http_file(
     name = "sops_windows",
-    # sha256 = "69cfb3eeaa0b77cc4923428855acdfc9ca9786544eeaff9c21913be830869d29",
-    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.exe"],
+    sha256 = "0ccda78bc7f7dbf3f07167221f2a42cab2b10d02de7c26fe8e707efaacaf3bd2",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.exe"],
     executable = True
   )

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -4,27 +4,39 @@ load(":sops_toolchain.bzl", "sops_toolchain")
 
 toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
 
-# Sops toolchain that points to sops binary version 3.5.0
+# Sops toolchain that points to sops binary version 3.7.3
 sops_toolchain(
-    name = "sops_darwin",
-    tool = "@sops_darwin//file",
+    name = "sops_darwin_amd64",
+    tool = "@sops_darwin_amd64//file",
     visibility = ["//visibility:public"],
 )
 
 sops_toolchain(
-    name = "sops_linux",
-    tool = "@sops_linux//file",
+    name = "sops_darwin_arm64",
+    tool = "@sops_darwin_arm64//file",
+    visibility = ["//visibility:public"],
+)
+
+sops_toolchain(
+    name = "sops_linux_amd64",
+    tool = "@sops_linux_amd64//file",
+    visibility = ["//visibility:public"],
+)
+
+sops_toolchain(
+    name = "sops_linux_arm64",
+    tool = "@sops_linux_arm64//file",
     visibility = ["//visibility:public"],
 )
 
 sops_toolchain(
     name = "sops_windows",
-    tool = "@sops_linux//file",
+    tool = "@sops_windows//file",
     visibility = ["//visibility:public"],
 )
 
 toolchain(
-    name = "sops_linux_toolchain",
+    name = "sops_linux_amd64_toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
@@ -33,17 +45,41 @@ toolchain(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
-    toolchain = ":sops_linux",
+    toolchain = ":sops_linux_amd64",
     toolchain_type = ":toolchain_type",
 )
 
 toolchain(
-    name = "sops_osx_toolchain",
+    name = "sops_linux_arm64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = ":sops_linux_arm64",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "sops_osx_amd64_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@platforms//cpu:x86_64",
     ],
-    toolchain = ":sops_darwin",
+    toolchain = ":sops_darwin_amd64",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "sops_osx_arm64_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:osx",
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = ":sops_darwin_arm64",
     toolchain_type = ":toolchain_type",
 )
 


### PR DESCRIPTION
Update sops to 3.7.3

 * Splits arm64/amd64 versions for linux/darwin
 * Permits helm_release() with SOPS secrets on M2 Mac