### PR TITLE
Sops add darwin arm64

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -35,7 +35,8 @@ def repositories():
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_linux_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/kubectl:kubectl_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/sops:sops_linux_toolchain",
-    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_amd64_toolchain",
+    "@com_github_masmovil_bazel_rules//toolchains/sops:sops_osx_arm64_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/sops:sops_windows_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_osx_toolchain",
     "@com_github_masmovil_bazel_rules//toolchains/gpg:gpg_linux_toolchain"

--- a/repositories/sops_repositories.bzl
+++ b/repositories/sops_repositories.bzl
@@ -3,14 +3,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sops_repositories():
   http_file(
     name = "sops_darwin_amd64",
-    sha256 = "",
+    sha256 = "d62c9a4404197b5e56b59a4974caeb44086dd8cc9a5dba903e949d3a0a8e1350",
     urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.amd64"],
     executable = True,
   )
 
   http_file(
     name = "sops_darwin_arm64",
-    sha256 = "",
+    sha256 = "be9ce265c7f3d3b534535d2a5ef7b41600bf2b8241b1a4f95e48804d20628b2e",
     urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.arm64"],
     executable = True,
   )

--- a/repositories/sops_repositories.bzl
+++ b/repositories/sops_repositories.bzl
@@ -2,10 +2,17 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def sops_repositories():
   http_file(
-    name = "sops_darwin",
-    # sha256 = "795f03364ed8499d169505021b443226b5a9ee9e8a58f560188a133870d194c9",
-    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.darwin"],
-    executable = True
+    name = "sops_darwin_amd64",
+    sha256 = "",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.amd64"],
+    executable = True,
+  )
+
+  http_file(
+    name = "sops_darwin_arm64",
+    sha256 = "",
+    urls = ["https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.darwin.arm64"],
+    executable = True,
   )
 
   http_file(

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -7,4 +7,6 @@ function decrypt_file() {
     SOPS_GPG_EXEC={GPG_BINARY} {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE} > $2
 }
 
+# Hack: Define $HOME so sops can grab things from there if the user has set it up in that way
+export HOME=$(realpath ~)
 {DECRYPT_FILES}

--- a/sops/sops-decrypt.sh.tpl
+++ b/sops/sops-decrypt.sh.tpl
@@ -7,6 +7,4 @@ function decrypt_file() {
     SOPS_GPG_EXEC={GPG_BINARY} {SOPS_BINARY_PATH} -d $1 --config {SOPS_CONFIG_FILE} > $2
 }
 
-# Hack: Define $HOME so sops can grab things from there if the user has set it up in that way
-export HOME=$(realpath ~)
 {DECRYPT_FILES}

--- a/toolchains/gpg/BUILD
+++ b/toolchains/gpg/BUILD
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:private"])
 
 load(":gpg_toolchain.bzl", "gpg_toolchain")
 
-toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Helm toolchain that points to gpg binary
 gpg_toolchain(
@@ -34,7 +37,7 @@ toolchain(
 toolchain(
     name = "gpg_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":gpg_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/helm-3/BUILD
+++ b/toolchains/helm-3/BUILD
@@ -21,7 +21,7 @@ toolchain(
 toolchain(
     name = "helm_v3.6.2_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = "@helm_toolchain_configure//:helm_v3.6.2_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/helm/BUILD
+++ b/toolchains/helm/BUILD
@@ -2,20 +2,23 @@ package(default_visibility = ["//visibility:private"])
 
 load(":helm_toolchain.bzl", "helm_toolchain")
 
-toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Helm toolchain that points to helm binary version 2.17.0
 helm_toolchain(
     name = "helm_v2.17.0_darwin",
-    tool = "@helm_v2.17.0_darwin//:helm",
     helm_version = "2.17.0",
+    tool = "@helm_v2.17.0_darwin//:helm",
     visibility = ["//visibility:public"],
 )
 
 helm_toolchain(
     name = "helm_v2.17.0_linux",
-    tool = "@helm_v2.17.0_linux//:helm",
     helm_version = "2.17.0",
+    tool = "@helm_v2.17.0_linux//:helm",
     visibility = ["//visibility:public"],
 )
 
@@ -36,7 +39,7 @@ toolchain(
 toolchain(
     name = "helm_v2.17.0_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":helm_v2.17.0_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:private"])
 
 load(":kubectl_toolchain.bzl", "kubectl_toolchain")
 
-toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Helm toolchain that points to helm binary version 2.13.0
 kubectl_toolchain(
@@ -34,7 +37,7 @@ toolchain(
 toolchain(
     name = "kubectl_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":kubectl_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -2,12 +2,20 @@ package(default_visibility = ["//visibility:private"])
 
 load(":sops_toolchain.bzl", "sops_toolchain")
 
-toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
-# Sops toolchain that points to sops binary version 3.5.0
 sops_toolchain(
-    name = "sops_darwin",
-    tool = "@sops_darwin//file",
+    name = "sops_darwin_amd64",
+    tool = "@sops_darwin_amd64//file",
+    visibility = ["//visibility:public"],
+)
+
+sops_toolchain(
+    name = "sops_darwin_arm64",
+    tool = "@sops_darwin_arm64//file",
     visibility = ["//visibility:public"],
 )
 
@@ -38,19 +46,29 @@ toolchain(
 )
 
 toolchain(
-    name = "sops_osx_toolchain",
+    name = "sops_osx_amd64_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
         "@platforms//cpu:x86_64",
     ],
-    toolchain = ":sops_darwin",
+    toolchain = ":sops_darwin_amd64",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "sops_osx_arm64_toolchain",
+    target_compatible_with = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = ":sops_darwin_arm64",
     toolchain_type = ":toolchain_type",
 )
 
 toolchain(
     name = "sops_windows_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     toolchain = ":sops_windows",
     toolchain_type = ":toolchain_type",

--- a/toolchains/yq/BUILD
+++ b/toolchains/yq/BUILD
@@ -41,7 +41,7 @@ toolchain(
 toolchain(
     name = "yq_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":yq_osx",
     toolchain_type = ":toolchain_type",


### PR DESCRIPTION
This adds support for darwin arm64 for sops now that the binaries for that platform were added in a recent release.
It also makes the repo work correctly with latest bazel, which requires the use of `@platforms` instead of `@bazel_tools/platforms`

I kept the patch as minimal as possible on purpose so it affects just sops and nothing else.