### PR TITLE
Replace `@bazel_tools//platforms` with `@platforms//os`

### DIFF
--- a/toolchains/gpg/BUILD
+++ b/toolchains/gpg/BUILD
@@ -34,7 +34,7 @@ toolchain(
 toolchain(
     name = "gpg_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":gpg_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/helm-3/BUILD
+++ b/toolchains/helm-3/BUILD
@@ -21,7 +21,7 @@ toolchain(
 toolchain(
     name = "helm_v3.6.2_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = "@helm_toolchain_configure//:helm_v3.6.2_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/helm/BUILD
+++ b/toolchains/helm/BUILD
@@ -36,7 +36,7 @@ toolchain(
 toolchain(
     name = "helm_v2.17.0_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":helm_v2.17.0_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -34,7 +34,7 @@ toolchain(
 toolchain(
     name = "kubectl_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":kubectl_darwin",
     toolchain_type = ":toolchain_type",

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -40,7 +40,7 @@ toolchain(
 toolchain(
     name = "sops_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
         "@platforms//cpu:x86_64",
     ],
     toolchain = ":sops_darwin",
@@ -50,7 +50,7 @@ toolchain(
 toolchain(
     name = "sops_windows_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     toolchain = ":sops_windows",
     toolchain_type = ":toolchain_type",

--- a/toolchains/yq/BUILD
+++ b/toolchains/yq/BUILD
@@ -41,7 +41,7 @@ toolchain(
 toolchain(
     name = "yq_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = ":yq_osx",
     toolchain_type = ":toolchain_type",


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel/issues/8622

Using `@bazel_tools//platforms` is no longer allowed in Bazel v6. This PR replaces all references and uses `@platforms//os` instead.