### PR TITLE
feat: upgrade docker rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,12 +2,10 @@ workspace(name = "com_github_masmovil_bazel_rules")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Download the rules_docker repository at release v0.9.0
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",
-    strip_prefix = "rules_docker-0.16.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.16.0/rules_docker-v0.16.0.tar.gz"],
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
 load(

--- a/toolchains/sops/BUILD
+++ b/toolchains/sops/BUILD
@@ -76,7 +76,7 @@ toolchain(
 toolchain(
     name = "sops_osx_arm64_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
         "@platforms//cpu:arm64",
     ],
     toolchain = ":sops_darwin_arm64",


### PR DESCRIPTION
In order to support bazel 6 rules docker needs to be upgraded to use new platform constraints.