### PR TITLE
Make helm-3 toolchain_type public

### DIFF
--- a/toolchains/helm-3/BUILD
+++ b/toolchains/helm-3/BUILD
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:private"])
 
 load(":toolchain.bzl", "helm_toolchain")
 
-toolchain_type(name = "toolchain_type")
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"]
+)
 
 toolchain(
     name = "helm_v3.6.2_linux_toolchain",


### PR DESCRIPTION
This allows the helm binary in the toolchain to be used by other rules.

An example is running Terratest helm tests. This shells out the the helm binary, if this is not on the PATH it fails. 

Making the toolchain_type public enables the following to reference the helm binary.

```
helm_toolchain = ctx.toolchains["@com_github_masmovil_bazel_rules//toolchains/helm-3:toolchain_type"].helminfo
helm = helm_toolchain.tool.files.to_list()[0]
```