### PR TITLE
fix(helm): reimplement lint rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 
-module(name = "masmovil_bazel_rules", version = "1.0.0", bazel_compatibility = [">=6.0.0"])
+module(name = "masmovil_bazel_rules", version = "1.0.1", bazel_compatibility = [">=6.0.0"])
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 


### PR DESCRIPTION
Reimplement `helm_lint` rule as a custom rule instead of bazel macro.

This way we don't need to define helm toolchain as a direct dependency of the host workspace.